### PR TITLE
Generate cyclist tokens

### DIFF
--- a/aws-precise-staging-1/main.tf
+++ b/aws-precise-staging-1/main.tf
@@ -1,5 +1,4 @@
 variable "aws_heroku_org" {}
-variable "cyclist_auth_tokens" {}
 variable "env" { default = "precise-staging" }
 variable "env_short" { default = "staging" }
 variable "index" { default = 1 }
@@ -16,6 +15,9 @@ data "terraform_remote_state" "vpc" {
     region = "us-east-1"
   }
 }
+
+resource "random_id" "cyclist_token_com" { byte_length = 32 }
+resource "random_id" "cyclist_token_org" { byte_length = 32 }
 
 module "aws_az_1b" {
   source = "../modules/aws_workers_az"
@@ -35,45 +37,9 @@ module "aws_az_1e" {
   vpc_id = "${data.terraform_remote_state.vpc.vpc_id}"
 }
 
-module "aws_asg_org" {
-  source = "../modules/aws_asg"
-  cyclist_auth_tokens = "${var.cyclist_auth_tokens}"
-  cyclist_debug = "true"
-  cyclist_scale = "web=1:Hobby"
-  cyclist_version = "v0.1.0"
-  env = "${var.env}"
-  env_short = "${var.env_short}"
-  heroku_org = "${var.aws_heroku_org}"
-  index = "${var.index}"
-  security_groups = "${module.aws_az_1b.workers_org_security_group_id},${module.aws_az_1e.workers_org_security_group_id}"
-  site = "org"
-  syslog_address = "${var.syslog_address}"
-  worker_ami = "${var.worker_ami}"
-  worker_asg_max_size = 3
-  worker_asg_min_size = 0
-  worker_asg_namespace = "Travis/org-staging"
-  worker_asg_scale_in_threshold = 16
-  worker_asg_scale_out_threshold = 8
-  worker_config = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_image_android = "quay.io/travisci/ci-android:packer-1473395968"
-  worker_docker_image_default = "quay.io/travisci/ci-ruby:packer-1473395984"
-  worker_docker_image_erlang = "quay.io/travisci/ci-erlang:packer-1473395969"
-  worker_docker_image_go = "quay.io/travisci/ci-go:packer-1473386112"
-  worker_docker_image_haskell = "quay.io/travisci/ci-haskell:packer-1473395984"
-  worker_docker_image_jvm = "quay.io/travisci/ci-jvm:packer-1473395987"
-  worker_docker_image_node_js = "quay.io/travisci/ci-nodejs:packer-1473395973"
-  worker_docker_image_perl = "quay.io/travisci/ci-perl:packer-1473395981"
-  worker_docker_image_php = "quay.io/travisci/ci-php:packer-1472315712"
-  worker_docker_image_python = "quay.io/travisci/ci-python:packer-1473396001"
-  worker_docker_image_ruby = "quay.io/travisci/ci-ruby:packer-1473395984"
-  worker_docker_self_image = "quay.io/travisci/worker:v2.4.0-23-g396d039"
-  worker_queue = "docker"
-  worker_subnets = "${data.terraform_remote_state.vpc.workers_org_subnet_1b_id},${data.terraform_remote_state.vpc.workers_org_subnet_1e_id}"
-}
-
 module "aws_asg_com" {
   source = "../modules/aws_asg"
-  cyclist_auth_tokens = "${var.cyclist_auth_tokens}"
+  cyclist_auth_token = "${random_id.cyclist_token_com.hex}"
   cyclist_debug = "true"
   cyclist_scale = "web=1:Hobby"
   cyclist_version = "v0.1.0"
@@ -105,4 +71,40 @@ module "aws_asg_com" {
   worker_docker_self_image = "quay.io/travisci/worker:v2.4.0-23-g396d039"
   worker_queue = "docker"
   worker_subnets = "${data.terraform_remote_state.vpc.workers_com_subnet_1b_id},${data.terraform_remote_state.vpc.workers_com_subnet_1e_id}"
+}
+
+module "aws_asg_org" {
+  source = "../modules/aws_asg"
+  cyclist_auth_token = "${random_id.cyclist_token_org.hex}"
+  cyclist_debug = "true"
+  cyclist_scale = "web=1:Hobby"
+  cyclist_version = "v0.1.0"
+  env = "${var.env}"
+  env_short = "${var.env_short}"
+  heroku_org = "${var.aws_heroku_org}"
+  index = "${var.index}"
+  security_groups = "${module.aws_az_1b.workers_org_security_group_id},${module.aws_az_1e.workers_org_security_group_id}"
+  site = "org"
+  syslog_address = "${var.syslog_address}"
+  worker_ami = "${var.worker_ami}"
+  worker_asg_max_size = 3
+  worker_asg_min_size = 0
+  worker_asg_namespace = "Travis/org-staging"
+  worker_asg_scale_in_threshold = 16
+  worker_asg_scale_out_threshold = 8
+  worker_config = "${file("${path.module}/config/worker-env-org")}"
+  worker_docker_image_android = "quay.io/travisci/ci-android:packer-1473395968"
+  worker_docker_image_default = "quay.io/travisci/ci-ruby:packer-1473395984"
+  worker_docker_image_erlang = "quay.io/travisci/ci-erlang:packer-1473395969"
+  worker_docker_image_go = "quay.io/travisci/ci-go:packer-1473386112"
+  worker_docker_image_haskell = "quay.io/travisci/ci-haskell:packer-1473395984"
+  worker_docker_image_jvm = "quay.io/travisci/ci-jvm:packer-1473395987"
+  worker_docker_image_node_js = "quay.io/travisci/ci-nodejs:packer-1473395973"
+  worker_docker_image_perl = "quay.io/travisci/ci-perl:packer-1473395981"
+  worker_docker_image_php = "quay.io/travisci/ci-php:packer-1472315712"
+  worker_docker_image_python = "quay.io/travisci/ci-python:packer-1473396001"
+  worker_docker_image_ruby = "quay.io/travisci/ci-ruby:packer-1473395984"
+  worker_docker_self_image = "quay.io/travisci/worker:v2.4.0-23-g396d039"
+  worker_queue = "docker"
+  worker_subnets = "${data.terraform_remote_state.vpc.workers_org_subnet_1b_id},${data.terraform_remote_state.vpc.workers_org_subnet_1e_id}"
 }

--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -1,5 +1,4 @@
 variable "aws_heroku_org" {}
-variable "cyclist_auth_tokens" {}
 variable "env" { default = "production" }
 variable "index" { default = 2 }
 variable "syslog_address" {}
@@ -15,6 +14,9 @@ data "terraform_remote_state" "vpc" {
     region = "us-east-1"
   }
 }
+
+resource "random_id" "cyclist_token_com" { byte_length = 32 }
+resource "random_id" "cyclist_token_org" { byte_length = 32 }
 
 module "aws_az_1b" {
   source = "../modules/aws_workers_az"
@@ -34,50 +36,9 @@ module "aws_az_1e" {
   vpc_id = "${data.terraform_remote_state.vpc.vpc_id}"
 }
 
-module "aws_asg_org" {
-  source = "../modules/aws_asg"
-  cyclist_auth_tokens = "${var.cyclist_auth_tokens}"
-  cyclist_version = "v0.1.0"
-  env = "${var.env}"
-  env_short = "${var.env}"
-  heroku_org = "${var.aws_heroku_org}"
-  index = "${var.index}"
-  security_groups = "${module.aws_az_1b.workers_org_security_group_id},${module.aws_az_1e.workers_org_security_group_id}"
-  site = "org"
-  syslog_address = "${var.syslog_address}"
-  worker_ami = "${var.worker_ami}"
-  # NOTE: builds.docker value for org production
-  # worker_asg_max_size = 75
-  worker_asg_max_size = 5
-  worker_asg_min_size = 0
-  worker_asg_namespace = "Travis/org"
-  # NOTE: builds.docker values for org production
-  # worker_asg_scale_in_threshold = 64
-  # worker_asg_scale_out_threshold = 48
-  worker_asg_scale_in_threshold = 16
-  worker_asg_scale_out_qty = 2
-  worker_asg_scale_out_threshold = 8
-  worker_config = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_image_android = "quay.io/travisci/ci-amethyst:packer-1473386113"
-  worker_docker_image_default = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_erlang = "quay.io/travisci/ci-amethyst:packer-1473386113"
-  worker_docker_image_go = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_haskell = "quay.io/travisci/ci-amethyst:packer-1473386113"
-  worker_docker_image_jvm = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_node_js = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_perl = "quay.io/travisci/ci-amethyst:packer-1473386113"
-  worker_docker_image_php = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_python = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_ruby = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_self_image = "quay.io/travisci/worker:v2.4.0-23-g396d039"
-  worker_instance_type = "c3.8xlarge"
-  worker_queue = "ec2"
-  worker_subnets = "${data.terraform_remote_state.vpc.workers_org_subnet_1b_id},${data.terraform_remote_state.vpc.workers_org_subnet_1e_id}"
-}
-
 module "aws_asg_com" {
   source = "../modules/aws_asg"
-  cyclist_auth_tokens = "${var.cyclist_auth_tokens}"
+  cyclist_auth_token = "${random_id.cyclist_token_com.hex}"
   cyclist_version = "v0.1.0"
   env = "${var.env}"
   env_short = "${var.env}"
@@ -114,4 +75,45 @@ module "aws_asg_com" {
   worker_instance_type = "c3.8xlarge"
   worker_queue = "ec2"
   worker_subnets = "${data.terraform_remote_state.vpc.workers_com_subnet_1b_id},${data.terraform_remote_state.vpc.workers_com_subnet_1e_id}"
+}
+
+module "aws_asg_org" {
+  source = "../modules/aws_asg"
+  cyclist_auth_token = "${random_id.cyclist_token_org.hex}"
+  cyclist_version = "v0.1.0"
+  env = "${var.env}"
+  env_short = "${var.env}"
+  heroku_org = "${var.aws_heroku_org}"
+  index = "${var.index}"
+  security_groups = "${module.aws_az_1b.workers_org_security_group_id},${module.aws_az_1e.workers_org_security_group_id}"
+  site = "org"
+  syslog_address = "${var.syslog_address}"
+  worker_ami = "${var.worker_ami}"
+  # NOTE: builds.docker value for org production
+  # worker_asg_max_size = 75
+  worker_asg_max_size = 5
+  worker_asg_min_size = 0
+  worker_asg_namespace = "Travis/org"
+  # NOTE: builds.docker values for org production
+  # worker_asg_scale_in_threshold = 64
+  # worker_asg_scale_out_threshold = 48
+  worker_asg_scale_in_threshold = 16
+  worker_asg_scale_out_qty = 2
+  worker_asg_scale_out_threshold = 8
+  worker_config = "${file("${path.module}/config/worker-env-org")}"
+  worker_docker_image_android = "quay.io/travisci/ci-amethyst:packer-1473386113"
+  worker_docker_image_default = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_erlang = "quay.io/travisci/ci-amethyst:packer-1473386113"
+  worker_docker_image_go = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_haskell = "quay.io/travisci/ci-amethyst:packer-1473386113"
+  worker_docker_image_jvm = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_node_js = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_perl = "quay.io/travisci/ci-amethyst:packer-1473386113"
+  worker_docker_image_php = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_python = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_ruby = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_self_image = "quay.io/travisci/worker:v2.4.0-23-g396d039"
+  worker_instance_type = "c3.8xlarge"
+  worker_queue = "ec2"
+  worker_subnets = "${data.terraform_remote_state.vpc.workers_org_subnet_1b_id},${data.terraform_remote_state.vpc.workers_org_subnet_1e_id}"
 }

--- a/aws-staging-1/main.tf
+++ b/aws-staging-1/main.tf
@@ -1,5 +1,4 @@
 variable "aws_heroku_org" {}
-variable "cyclist_auth_tokens" {}
 variable "env" { default = "staging" }
 variable "index" { default = 1 }
 variable "syslog_address" {}
@@ -15,6 +14,9 @@ data "terraform_remote_state" "vpc" {
     region = "us-east-1"
   }
 }
+
+resource "random_id" "cyclist_token_com" { byte_length = 32 }
+resource "random_id" "cyclist_token_org" { byte_length = 32 }
 
 module "aws_az_1b" {
   source = "../modules/aws_workers_az"
@@ -34,45 +36,9 @@ module "aws_az_1e" {
   vpc_id = "${data.terraform_remote_state.vpc.vpc_id}"
 }
 
-module "aws_asg_org" {
-  source = "../modules/aws_asg"
-  cyclist_auth_tokens = "${var.cyclist_auth_tokens}"
-  cyclist_debug = "true"
-  cyclist_scale = "web=1:Hobby"
-  cyclist_version = "v0.1.0"
-  env = "${var.env}"
-  env_short = "${var.env}"
-  heroku_org = "${var.aws_heroku_org}"
-  index = "${var.index}"
-  security_groups = "${module.aws_az_1b.workers_org_security_group_id},${module.aws_az_1e.workers_org_security_group_id}"
-  site = "org"
-  syslog_address = "${var.syslog_address}"
-  worker_ami = "${var.worker_ami}"
-  worker_asg_max_size = 3
-  worker_asg_min_size = 0
-  worker_asg_namespace = "Travis/org-staging"
-  worker_asg_scale_in_threshold = 16
-  worker_asg_scale_out_threshold = 8
-  worker_config = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_image_android = "quay.io/travisci/ci-amethyst:packer-1473386113"
-  worker_docker_image_default = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_erlang = "quay.io/travisci/ci-amethyst:packer-1473386113"
-  worker_docker_image_go = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_haskell = "quay.io/travisci/ci-amethyst:packer-1473386113"
-  worker_docker_image_jvm = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_node_js = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_perl = "quay.io/travisci/ci-amethyst:packer-1473386113"
-  worker_docker_image_php = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_python = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_image_ruby = "quay.io/travisci/ci-garnet:packer-1473395986"
-  worker_docker_self_image = "quay.io/travisci/worker:v2.4.0-23-g396d039"
-  worker_queue = "ec2"
-  worker_subnets = "${data.terraform_remote_state.vpc.workers_org_subnet_1b_id},${data.terraform_remote_state.vpc.workers_org_subnet_1e_id}"
-}
-
 module "aws_asg_com" {
   source = "../modules/aws_asg"
-  cyclist_auth_tokens = "${var.cyclist_auth_tokens}"
+  cyclist_auth_token = "${random_id.cyclist_token_com.hex}"
   cyclist_debug = "true"
   cyclist_scale = "web=1:Hobby"
   cyclist_version = "v0.1.0"
@@ -104,4 +70,40 @@ module "aws_asg_com" {
   worker_docker_self_image = "quay.io/travisci/worker:v2.4.0-23-g396d039"
   worker_queue = "ec2"
   worker_subnets = "${data.terraform_remote_state.vpc.workers_com_subnet_1b_id},${data.terraform_remote_state.vpc.workers_com_subnet_1e_id}"
+}
+
+module "aws_asg_org" {
+  source = "../modules/aws_asg"
+  cyclist_auth_token = "${random_id.cyclist_token_org.hex}"
+  cyclist_debug = "true"
+  cyclist_scale = "web=1:Hobby"
+  cyclist_version = "v0.1.0"
+  env = "${var.env}"
+  env_short = "${var.env}"
+  heroku_org = "${var.aws_heroku_org}"
+  index = "${var.index}"
+  security_groups = "${module.aws_az_1b.workers_org_security_group_id},${module.aws_az_1e.workers_org_security_group_id}"
+  site = "org"
+  syslog_address = "${var.syslog_address}"
+  worker_ami = "${var.worker_ami}"
+  worker_asg_max_size = 3
+  worker_asg_min_size = 0
+  worker_asg_namespace = "Travis/org-staging"
+  worker_asg_scale_in_threshold = 16
+  worker_asg_scale_out_threshold = 8
+  worker_config = "${file("${path.module}/config/worker-env-org")}"
+  worker_docker_image_android = "quay.io/travisci/ci-amethyst:packer-1473386113"
+  worker_docker_image_default = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_erlang = "quay.io/travisci/ci-amethyst:packer-1473386113"
+  worker_docker_image_go = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_haskell = "quay.io/travisci/ci-amethyst:packer-1473386113"
+  worker_docker_image_jvm = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_node_js = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_perl = "quay.io/travisci/ci-amethyst:packer-1473386113"
+  worker_docker_image_php = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_python = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_image_ruby = "quay.io/travisci/ci-garnet:packer-1473395986"
+  worker_docker_self_image = "quay.io/travisci/worker:v2.4.0-23-g396d039"
+  worker_queue = "ec2"
+  worker_subnets = "${data.terraform_remote_state.vpc.workers_org_subnet_1b_id},${data.terraform_remote_state.vpc.workers_org_subnet_1e_id}"
 }

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -1,4 +1,4 @@
-variable "cyclist_auth_tokens" {}
+variable "cyclist_auth_token" {}
 variable "cyclist_aws_region" { default = "us-east-1" }
 variable "cyclist_debug" { default = "false" }
 variable "cyclist_redis_plan" { default = "premium-0" }
@@ -41,7 +41,7 @@ variable "worker_subnets" {}
 data "template_file" "worker_cloud_init" {
   template = "${file("${path.module}/worker-cloud-init.tpl")}"
   vars {
-    cyclist_auth_token = "${element(split(",", var.cyclist_auth_tokens), var.index)}"
+    cyclist_auth_token = "${var.cyclist_auth_token}"
     cyclist_url = "${replace(heroku_app.cyclist.web_url, "/\\/$/", "")}"
     env = "${var.env}"
     index = "${var.index}"
@@ -276,7 +276,7 @@ resource "heroku_app" "cyclist" {
     AWS_REGION = "${var.cyclist_aws_region}"
     AWS_SECRET_KEY = "${aws_iam_access_key.cyclist.secret}"
     BUILDPACK_URL = "https://github.com/travis-ci/heroku-buildpack-makey-go"
-    CYCLIST_AUTH_TOKENS = "${var.cyclist_auth_tokens}"
+    CYCLIST_AUTH_TOKENS = "${var.cyclist_auth_token}"
     CYCLIST_DEBUG = "${var.cyclist_debug}"
     GO_IMPORT_PATH = "github.com/travis-ci/cyclist"
   }


### PR DESCRIPTION
since we should never need to have a record of them outside of terraform state or heroku config.

**NOTE** this diff includes re ordering the module declarations so that "com" comes before "org"

*update*: By default, the `random_id` resource will persist the result in the terraform state, and because we have no triggers defined it will not change unless we explicitly destroy/rebuild.  This can most easily be done with the `taint` command, e.g.:

``` bash
terraform taint random_id.cyclist_token_com
# => The resource random_id.cyclist_token_com in the module root has been marked as tainted! 
```