### PR TITLE
Set LC_ALL=C before calling sort

### DIFF
--- a/bin/generate-github-ssh-users
+++ b/bin/generate-github-ssh-users
@@ -33,7 +33,7 @@ __github_users() {
       | jq -r ".[]|select(.name==\"${team}\")|.id"
   )"
   __ghcurl "${auth}" "/teams/${team_id}/members" | jq -r '.[]|.login' \
-    | sort \
+    | LC_ALL=C sort \
     | while read -r login; do
       __ghcurl "${auth}" "/users/${login}" \
         | jq -r '[(.name|split(" ")|.[0]|ascii_downcase), .login]|join(":")'

--- a/bin/heroku-dump-shell-config
+++ b/bin/heroku-dump-shell-config
@@ -33,7 +33,7 @@ __heroku_dump_shell_config() {
     | jq -r ". | to_entries | .[] \
       | [\"export \", (.key|ascii_upcase), \"=\", (.value|@sh)] \
       | join(\"\")" \
-    | sort
+    | LC_ALL=C sort
 }
 
 __heroku_curl() {

--- a/bin/show-current-docker-images
+++ b/bin/show-current-docker-images
@@ -12,7 +12,7 @@ main() {
     }' \
     | sed 's/  *$//' \
     | tr '[:upper:]' '[:lower:]' \
-    | sort \
+    | LC_ALL=C sort \
     | uniq
 }
 

--- a/runtests
+++ b/runtests
@@ -35,7 +35,7 @@ for f in $(git ls-files '*.bats'); do
   bats -t "${f}"
 done
 
-for d in $(git ls-files '*.tf' | xargs -n1 dirname | sort | uniq); do
+for d in $(git ls-files '*.tf' | xargs -n1 dirname | LC_ALL=C sort | uniq); do
   echo -en "${d} "
   terraform validate "${d}"
   echo "✓"


### PR DESCRIPTION
This makes the sorts care about raw byte values instead of doing locale-based sorts, which is especially important for the commands that generate data for the startup scripts in order to make them stable across different platforms running Terraform.