### PR TITLE
Add subnet for packer builds

### DIFF
--- a/modules/aws_docker_registry/main.tf
+++ b/modules/aws_docker_registry/main.tf
@@ -69,7 +69,7 @@ resource "aws_instance" "registry" {
   instance_type = "${var.instance_type}"
   subnet_id = "${var.public_subnet_id}"
   vpc_security_group_ids = ["${aws_security_group.registry.id}"]
-  associate_public_ip_address = false
+  associate_public_ip_address = true
   tags = {
     Name = "${var.env}-${var.index}-registry-${var.az}"
   }


### PR DESCRIPTION
to replace decommissioned subnet from elder infra.

The extra change in `modules/aws_docker_registry/main.tf` is to address an unrelated bit that kept churning.