### PR TITLE
gce-production-6

### DIFF
--- a/gce-production-6/Makefile
+++ b/gce-production-6/Makefile
@@ -1,0 +1,1 @@
+include $(shell git rev-parse --show-toplevel)/gce.mk

--- a/gce-production-6/main.tf
+++ b/gce-production-6/main.tf
@@ -1,47 +1,44 @@
-variable "env" { default = "staging" }
+variable "env" { default = "production" }
 variable "gce_bastion_image" { default = "eco-emissary-99515/bastion-1478778272" }
 variable "gce_gcloud_zone" {}
 variable "gce_heroku_org" {}
 variable "gce_worker_image" { default = "eco-emissary-99515/travis-worker-1480649763" }
 variable "github_users" {}
-variable "index" { default = 2 }
 variable "job_board_url" {}
 variable "travisci_net_external_zone_id" { default = "Z2RI61YP4UWSIO" }
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 
 provider "google" {
-  project = "travis-staging-2"
+  project = "travis-ci-prod-6"
 }
 
 provider "aws" {}
 
 provider "heroku" {}
 
-module "gce_project_2" {
+module "gce_project_6" {
   source = "../modules/gce_project"
   bastion_config = "${file("${path.module}/config/bastion-env")}"
   bastion_image = "${var.gce_bastion_image}"
   env = "${var.env}"
   github_users = "${var.github_users}"
-  gcloud_cleanup_account_json = "${file("${path.module}/config/gce-cleanup-staging-2.json")}"
+  gcloud_cleanup_account_json = "${file("${path.module}/config/gce-cleanup-production-6.json")}"
   gcloud_cleanup_job_board_url = "${var.job_board_url}"
-  gcloud_cleanup_loop_sleep = "2m"
-  gcloud_cleanup_scale = "worker=1:Hobby"
   gcloud_zone = "${var.gce_gcloud_zone}"
   heroku_org = "${var.gce_heroku_org}"
-  index = "${var.index}"
-  project = "travis-staging-2"
+  index = "6"
+  project = "travis-ci-prod-6"
   syslog_address_com = "${var.syslog_address_com}"
   syslog_address_org = "${var.syslog_address_org}"
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
-  worker_account_json_com = "${file("${path.module}/config/gce-workers-staging-2.json")}"
-  worker_account_json_org = "${file("${path.module}/config/gce-workers-staging-2.json")}"
+  worker_account_json_com = "${file("${path.module}/config/gce-workers-production-6.json")}"
+  worker_account_json_org = "${file("${path.module}/config/gce-workers-production-6.json")}"
   worker_config_com = "${file("${path.module}/config/worker-env-com")}"
   worker_config_org = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_self_image = "travisci/worker:v2.6.2"
+  worker_docker_self_image = "travisci/worker:v2.7.0"
   worker_image = "${var.gce_worker_image}"
   # instance count must be a multiple of number of zones (currently 2)
-  worker_instance_count_com = 0
-  worker_instance_count_org = 2
+  worker_instance_count_com = 2
+  worker_instance_count_org = 0
 }


### PR DESCRIPTION
This creates two `com` workers in the new `travis-ci-prod-6` project on GCE. They are listening on the `builds.gce-canary` queue.

Keychain PRs:

* https://github.com/travis-pro/travis-keychain/pull/207
* https://github.com/travis-pro/travis-pro-keychain/pull/127