### PR TITLE
fetch as much config as possible from the keychain

### DIFF
--- a/macstadium-shared-1/.example.env
+++ b/macstadium-shared-1/.example.env
@@ -1,7 +1,2 @@
-export VSPHERE_USER='foobar'
-export VSPHERE_PASSWORD='foobar'
-export VSPHERE_SERVER='0.0.0.0'
-
-export TF_VAR_threatstack_key='foobar'
 # Change this if your user you SSH with is different than your local user
 export TF_VAR_ssh_user="$USER"

--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -23,9 +23,17 @@ variable "collectd_vsphere_collectd_network_user" {}
 variable "collectd_vsphere_collectd_network_token" {}
 variable "fw_ip" {}
 variable "fw_snmp_community" {}
+variable "vsphere_user" {}
+variable "vsphere_password" {}
+variable "vsphere_server" {}
 
 provider "aws" {}
-provider "vsphere" {}
+provider "vsphere" {
+  user           = "${var.vsphere_user}"
+  password       = "${var.vsphere_password}"
+  vsphere_server = "${var.vsphere_server}"
+  allow_unverified_ssl = true
+}
 
 module "macstadium_infrastructure" {
   source = "../modules/macstadium_infrastructure"


### PR DESCRIPTION
Refs https://github.com/travis-pro/travis-keychain/pull/216.

That means `make plan` should work off the bat, as long as `TF_VAR_ssh_user` is set (as per `.exmaple.env`)!