### PR TITLE
macstadium-shared: add dns records for wjb and vsphere

### DIFF
--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -26,6 +26,7 @@ variable "fw_snmp_community" {}
 variable "vsphere_user" {}
 variable "vsphere_password" {}
 variable "vsphere_server" {}
+variable "vsphere_ip" {}
 
 provider "aws" {}
 provider "vsphere" {
@@ -45,9 +46,10 @@ module "macstadium_infrastructure" {
   internal_network_label = "dvPortGroup-Internal"
   management_network_label = "dvPortGroup-Mgmt"
   jobs_network_label = "dvPortGroup-Jobs"
-  wjb_num = 1
   ssh_user = "${var.ssh_user}"
   threatstack_key = "${var.threatstack_key}"
+  travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
+  vsphere_ip = "${var.vsphere_ip}"
 }
 
 module "jupiter_brain_prod_com" {

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -20,6 +20,7 @@ variable "fw_snmp_community" {}
 variable "vsphere_user" {}
 variable "vsphere_password" {}
 variable "vsphere_server" {}
+variable "vsphere_ip" {}
 
 provider "aws" {}
 provider "vsphere" {
@@ -39,9 +40,10 @@ module "macstadium_infrastructure" {
   internal_network_label = "dvPortGroup-Internal"
   management_network_label = "dvPortGroup-Mgmt"
   jobs_network_label = "dvPortGroup-Jobs"
-  wjb_num = 2
   ssh_user = "${var.ssh_user}"
   threatstack_key = "${var.threatstack_key}"
+  travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
+  vsphere_ip = "${var.vsphere_ip}"
 }
 
 module "jupiter_brain_prod_com" {

--- a/modules/macstadium_infrastructure/dns.tf
+++ b/modules/macstadium_infrastructure/dns.tf
@@ -1,0 +1,15 @@
+resource "aws_route53_record" "vsphere" {
+  zone_id = "${var.travisci_net_external_zone_id}"
+  name = "vsphere-${var.index}.macstadium-us-se-1.travisci.net"
+  type = "A"
+  ttl = 300
+  records = ["${var.vsphere_ip}"]
+}
+
+resource "aws_route53_record" "wjb" {
+  zone_id = "${var.travisci_net_external_zone_id}"
+  name = "wjb-${var.index}.macstadium-us-se-1.travisci.net"
+  type = "A"
+  ttl = 300
+  records = ["${vsphere_virtual_machine.wjb.network_interface.0.ipv4_address}"]
+}

--- a/modules/macstadium_infrastructure/variables.tf
+++ b/modules/macstadium_infrastructure/variables.tf
@@ -6,6 +6,7 @@ variable "datastore" {}
 variable "internal_network_label" {}
 variable "management_network_label" {}
 variable "jobs_network_label" {}
-variable "wjb_num" {}
 variable "threatstack_key" {}
+variable "travisci_net_external_zone_id" {}
+variable "vsphere_ip" {}
 variable "ssh_user" {}

--- a/modules/macstadium_infrastructure/wjb.tf
+++ b/modules/macstadium_infrastructure/wjb.tf
@@ -1,5 +1,5 @@
 resource "vsphere_virtual_machine" "wjb" {
-  name = "wjb-${var.wjb_num}"
+  name = "wjb-${var.index}"
   folder = "${vsphere_folder.internal_vms.path}"
   vcpu = 4
   memory = 4096
@@ -9,20 +9,20 @@ resource "vsphere_virtual_machine" "wjb" {
 
   network_interface {
     label = "${var.internal_network_label}"
-    ipv4_address = "${cidrhost("10.182.64.0/18", 30 + var.wjb_num)}"
+    ipv4_address = "${cidrhost("10.182.64.0/18", 30 + var.index)}"
     ipv4_gateway = "10.182.64.1"
     ipv4_prefix_length = "18"
   }
 
   network_interface {
     label = "${var.jobs_network_label}"
-    ipv4_address = "${cidrhost("10.182.0.0/18", 30 + var.wjb_num)}"
+    ipv4_address = "${cidrhost("10.182.0.0/18", 30 + var.index)}"
     ipv4_prefix_length = "18"
   }
 
   network_interface {
     label = "${var.management_network_label}"
-    ipv4_address = "${cidrhost("10.88.208.0/23", 496 + var.wjb_num)}"
+    ipv4_address = "${cidrhost("10.88.208.0/23", 496 + var.index)}"
     ipv4_prefix_length = "23"
   }
 


### PR DESCRIPTION
Incorporates https://github.com/travis-pro/travis-keychain/pull/221 to produce 4 new hostnames:

* `wjb-1.macstadium-us-se-1.travisci.net`
* `wjb-2.macstadium-us-se-1.travisci.net`
* `vsphere-1.macstadium-us-se-1.travisci.net`
* `vsphere-2.macstadium-us-se-1.travisci.net`