### PR TITLE
Fail early on install scripts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+indent_style = space
+indent_size = 2
+
+[{Makefile,*.mk}]
+indent_style = tab
+indent_size = 4

--- a/modules/collectd_vsphere/install-collectd-vsphere.sh
+++ b/modules/collectd_vsphere/install-collectd-vsphere.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if ! getent passwd collectd-vsphere >/dev/null; then
   sudo useradd -r -s /usr/bin/nologin collectd-vsphere
 fi

--- a/modules/jupiter_brain_bluegreen/install-jupiter-brain.sh
+++ b/modules/jupiter_brain_bluegreen/install-jupiter-brain.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Create jupiter-brain user if it doesn't exist
 if ! getent passwd jupiter-brain >/dev/null; then
     sudo useradd -r -s /usr/bin/nologin jupiter-brain

--- a/modules/macstadium_go_worker/install-worker.sh
+++ b/modules/macstadium_go_worker/install-worker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Create travis-worker user if it doesn't exist
 if ! getent passwd travis-worker >/dev/null; then
     sudo useradd -r -s /usr/bin/nologin travis-worker


### PR DESCRIPTION
This (1) causes the install scripts to fail as soon as a sub-command fails and (2) causes the install script itself to fail, which means that the Terraform run fails too (it didn't before, it would just "silently" continue).

Also adds an .editorconfig file with what I think is the settings we've used in the files in this repo.