### PR TITLE
macstadium: move vm ssh key upload to wjb tf file

### DIFF
--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -50,6 +50,7 @@ module "macstadium_infrastructure" {
   threatstack_key = "${var.threatstack_key}"
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
   vsphere_ip = "${var.vsphere_ip}"
+  vm_ssh_key_path = "${path.module}/config/travis-vm-ssh-key"
 }
 
 module "jupiter_brain_production_com" {
@@ -119,7 +120,6 @@ module "worker_production_com_1" {
   ssh_user = "${var.ssh_user}"
   version = "${var.travis_worker_production_version}"
   config_path = "${path.module}/config/travis-worker-production-com-1"
-  vm_ssh_key_path = "${path.module}/config/travis-vm-ssh-key"
   env = "production-com-1"
   index = "${var.index}"
 }
@@ -131,7 +131,6 @@ module "worker_production_com_2" {
   ssh_user = "${var.ssh_user}"
   version = "${var.travis_worker_production_version}"
   config_path = "${path.module}/config/travis-worker-production-com-2"
-  vm_ssh_key_path = "${path.module}/config/travis-vm-ssh-key"
   env = "production-com-2"
   index = "${var.index}"
 }
@@ -143,7 +142,6 @@ module "worker_staging_com_1" {
   ssh_user = "${var.ssh_user}"
   version = "${var.travis_worker_staging_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-1"
-  vm_ssh_key_path = "${path.module}/config/travis-vm-ssh-key"
   env = "staging-com-1"
   index = "${var.index}"
 }
@@ -155,7 +153,6 @@ module "worker_staging_com_2" {
   ssh_user = "${var.ssh_user}"
   version = "${var.travis_worker_staging_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-2"
-  vm_ssh_key_path = "${path.module}/config/travis-vm-ssh-key"
   env = "staging-com-2"
   index = "${var.index}"
 }
@@ -167,7 +164,6 @@ module "worker_custom_1" {
   ssh_user = "${var.ssh_user}"
   version = "${var.travis_worker_custom-1_version}"
   config_path = "${path.module}/config/travis-worker-custom-1"
-  vm_ssh_key_path = "${path.module}/config/travis-vm-ssh-key"
   env = "custom-1"
   index = "${var.index}"
 }
@@ -179,7 +175,6 @@ module "worker_custom_2" {
   ssh_user = "${var.ssh_user}"
   version = "${var.travis_worker_custom-2_version}"
   config_path = "${path.module}/config/travis-worker-custom-2"
-  vm_ssh_key_path = "${path.module}/config/travis-vm-ssh-key"
   env = "custom-2"
   index = "${var.index}"
 }
@@ -191,7 +186,6 @@ module "worker_custom_3" {
   ssh_user = "${var.ssh_user}"
   version = "${var.travis_worker_custom-3_version}"
   config_path = "${path.module}/config/travis-worker-custom-3"
-  vm_ssh_key_path = "${path.module}/config/travis-vm-ssh-key"
   env = "custom-3"
   index = "${var.index}"
 }

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -44,6 +44,7 @@ module "macstadium_infrastructure" {
   threatstack_key = "${var.threatstack_key}"
   travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
   vsphere_ip = "${var.vsphere_ip}"
+  vm_ssh_key_path = "${path.module}/config/travis-vm-ssh-key"
 }
 
 module "jupiter_brain_production_com" {
@@ -77,7 +78,6 @@ module "worker_staging_com_1" {
   ssh_user = "${var.ssh_user}"
   version = "${var.travis_worker_staging_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-1"
-  vm_ssh_key_path = "${path.module}/config/travis-vm-ssh-key"
   env = "staging-com-1"
   index = "${var.index}"
 }
@@ -89,7 +89,6 @@ module "worker_com_staging_2" {
   ssh_user = "${var.ssh_user}"
   version = "${var.travis_worker_staging_version}"
   config_path = "${path.module}/config/travis-worker-staging-com-2"
-  vm_ssh_key_path = "${path.module}/config/travis-vm-ssh-key"
   env = "staging-com-2"
   index = "${var.index}"
 }

--- a/modules/macstadium_go_worker/install-worker.sh
+++ b/modules/macstadium_go_worker/install-worker.sh
@@ -12,11 +12,6 @@ sudo mv /tmp/etc-default-travis-worker-${env} /etc/default/travis-worker-${env}
 sudo chown travis-worker:travis-worker /etc/default/travis-worker-${env}
 sudo chmod 0600 /etc/default/travis-worker-${env}
 
-# Move the SSH key in place and correct permissions
-sudo mv /tmp/travis-vm-ssh-key /etc/travis-vm-ssh-key
-sudo chown travis-worker:travis-worker /etc/travis-vm-ssh-key
-sudo chmod 0600 /etc/travis-vm-ssh-key
-
 # Configure upstart
 sudo mkdir -p /var/tmp/run/travis-worker
 sudo chown travis-worker:travis-worker /var/tmp/run/travis-worker

--- a/modules/macstadium_go_worker/worker.tf
+++ b/modules/macstadium_go_worker/worker.tf
@@ -2,7 +2,6 @@ variable "ssh_host" {}
 variable "ssh_user" {}
 variable "version" {}
 variable "config_path" {}
-variable "vm_ssh_key_path" {}
 variable "env" {}
 variable "index" {}
 variable "host_id" {}
@@ -31,7 +30,6 @@ resource "null_resource" "worker" {
     config_signature = "${sha256(file(var.config_path))}"
     install_script_signature = "${sha256(data.template_file.worker_install.rendered)}"
     upstart_script_signature = "${sha256(data.template_file.worker_upstart.rendered)}"
-    ssh_key_signature = "${sha256(file(var.vm_ssh_key_path))}"
     name = "${var.env}-${var.index}"
     host_id = "${var.host_id}"
   }
@@ -50,11 +48,6 @@ resource "null_resource" "worker" {
   provisioner "file" {
     content = "${data.template_file.worker_upstart.rendered}"
     destination = "/tmp/init-travis-worker-${var.env}.conf"
-  }
-
-  provisioner "file" {
-    source = "${var.vm_ssh_key_path}"
-    destination = "/tmp/travis-vm-ssh-key"
   }
 
   provisioner "remote-exec" {

--- a/modules/macstadium_infrastructure/variables.tf
+++ b/modules/macstadium_infrastructure/variables.tf
@@ -10,3 +10,4 @@ variable "threatstack_key" {}
 variable "travisci_net_external_zone_id" {}
 variable "vsphere_ip" {}
 variable "ssh_user" {}
+variable "vm_ssh_key_path" {}

--- a/modules/macstadium_infrastructure/wjb.tf
+++ b/modules/macstadium_infrastructure/wjb.tf
@@ -44,5 +44,30 @@ resource "vsphere_virtual_machine" "wjb" {
   }
 }
 
+resource "null_resource" "worker" {
+  triggers {
+    ssh_key_file_signature = "${sha256(file(var.vm_ssh_key_path))}"
+  }
+
+  connection {
+    host = "${vsphere_virtual_machine.wjb.network_interface.0.ipv4_address}"
+    user = "${var.ssh_user}"
+    agent = true
+  }
+
+  provisioner "file" {
+    source      = "${var.vm_ssh_key_path}"
+    destination = "/tmp/travis-vm-ssh-key"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "sudo mv /tmp/travis-vm-ssh-key /etc/travis-vm-ssh-key",
+      "sudo chown travis-worker:travis-worker /etc/travis-vm-ssh-key",
+      "sudo chmod 0600 /etc/travis-vm-ssh-key",
+    ]
+  }
+}
+
 output "wjb_ip" { value = "${vsphere_virtual_machine.wjb.network_interface.0.ipv4_address}" }
 output "wjb_uuid" { value = "${vsphere_virtual_machine.wjb.uuid}" }

--- a/modules/macstadium_infrastructure/wjb.tf
+++ b/modules/macstadium_infrastructure/wjb.tf
@@ -63,6 +63,7 @@ resource "null_resource" "worker" {
 
   provisioner "remote-exec" {
     inline = [
+      "if ! getent passwd travis-worker >/dev/null; then sudo useradd -r -s /usr/bin/nologin travis-worker; fi"
       "sudo mv /tmp/travis-vm-ssh-key /etc/travis-vm-ssh-key",
       "sudo chown travis-worker:travis-worker /etc/travis-vm-ssh-key",
       "sudo chmod 0600 /etc/travis-vm-ssh-key",

--- a/modules/macstadium_infrastructure/wjb.tf
+++ b/modules/macstadium_infrastructure/wjb.tf
@@ -63,7 +63,7 @@ resource "null_resource" "worker" {
 
   provisioner "remote-exec" {
     inline = [
-      "if ! getent passwd travis-worker >/dev/null; then sudo useradd -r -s /usr/bin/nologin travis-worker; fi"
+      "if ! getent passwd travis-worker >/dev/null; then sudo useradd -r -s /usr/bin/nologin travis-worker; fi",
       "sudo mv /tmp/travis-vm-ssh-key /etc/travis-vm-ssh-key",
       "sudo chown travis-worker:travis-worker /etc/travis-vm-ssh-key",
       "sudo chmod 0600 /etc/travis-vm-ssh-key",

--- a/modules/macstadium_infrastructure/wjb.tf
+++ b/modules/macstadium_infrastructure/wjb.tf
@@ -46,6 +46,7 @@ resource "vsphere_virtual_machine" "wjb" {
 
 resource "null_resource" "worker" {
   triggers {
+    host_id = "${vsphere_virtual_machine.wjb.uuid}"
     ssh_key_file_signature = "${sha256(file(var.vm_ssh_key_path))}"
   }
 


### PR DESCRIPTION
This file only exists once per wjb, so having it in the worker module caused all the parallel worker modules to "fight" over the file as they were running, causing some odd race conditions.