### PR TITLE
macstadium: add jupiter brain and workers for an Xserve .com setup

### DIFF
--- a/macstadium-shared-1/Makefile
+++ b/macstadium-shared-1/Makefile
@@ -28,9 +28,12 @@ CONFIG_FILES := \
 		config/vsphere-janitor-custom-4 \
 		config/vsphere-janitor-custom-5 \
 		config/jupiter-brain-production-com-env \
+		config/jupiter-brain-production-com-xserve-env \
 		config/jupiter-brain-staging-com-env \
 		config/travis-worker-production-com-1 \
 		config/travis-worker-production-com-2 \
+		config/travis-worker-production-com-xserve-1 \
+		config/travis-worker-production-com-xserve-2 \
 		config/travis-worker-staging-com-1 \
 		config/travis-worker-staging-com-2 \
 		config/collectd-vsphere-common \
@@ -92,6 +95,8 @@ $(CONFIG_FILES):
 		| sed 's/^/export /' >config/vsphere-janitor-custom-5
 	trvs generate-config -n --pro -p JUPITER_BRAIN -f env jupiter-brain production-$(INDEX) \
 		| sed 's/^/export /' >config/jupiter-brain-production-com-env
+	trvs generate-config -n --pro -p JUPITER_BRAIN -f env jupiter-brain production-$(INDEX)-xserve \
+		| sed 's/^/export /' >config/jupiter-brain-production-com-xserve-env
 	trvs generate-config -n --pro -p JUPITER_BRAIN -f env jupiter-brain staging-$(INDEX) \
 		| sed 's/^/export /' >config/jupiter-brain-staging-com-env
 	trvs generate-config -n --pro -p TRAVIS_WORKER -f env macstadium-workers staging-$(INDEX)-1 \
@@ -102,6 +107,10 @@ $(CONFIG_FILES):
 		| sed 's/^/export /' >config/travis-worker-production-com-1
 	trvs generate-config -n --pro -p TRAVIS_WORKER -f env macstadium-workers production-$(INDEX)-2 \
 		| sed 's/^/export /' >config/travis-worker-production-com-2
+	trvs generate-config -n --pro -p TRAVIS_WORKER -f env macstadium-workers production-$(INDEX)-xserve-1 \
+		| sed 's/^/export /' >config/travis-worker-production-com-xserve-1
+	trvs generate-config -n --pro -p TRAVIS_WORKER -f env macstadium-workers production-$(INDEX)-xserve-2 \
+		| sed 's/^/export /' >config/travis-worker-production-com-xserve-2
 	trvs generate-config -n -p COLLECTD_VSPHERE -f env collectd-vsphere common-$(INDEX) \
 		| sed 's/^/export /' >config/collectd-vsphere-common
 

--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -90,6 +90,18 @@ module "jupiter_brain_production_com" {
   port_suffix = 3
 }
 
+module "jupiter_brain_production_com_xserve" {
+  source = "../modules/jupiter_brain_bluegreen"
+  host_id = "${module.macstadium_infrastructure.wjb_uuid}"
+  ssh_ip_address = "${module.macstadium_infrastructure.wjb_ip}"
+  ssh_user = "${var.ssh_user}"
+  version = "${var.jupiter_brain_production_version}"
+  config_path = "${path.module}/config/jupiter-brain-production-com-xserve-env"
+  env = "production-com-xserve"
+  index = "${var.index}"
+  port_suffix = 10
+}
+
 module "jupiter_brain_staging_com" {
   source = "../modules/jupiter_brain_bluegreen"
   host_id = "${module.macstadium_infrastructure.wjb_uuid}"
@@ -203,6 +215,28 @@ module "worker_production_com_2" {
   version = "${var.travis_worker_production_version}"
   config_path = "${path.module}/config/travis-worker-production-com-2"
   env = "production-com-2"
+  index = "${var.index}"
+}
+
+module "worker_production_com_xserve_1" {
+  source = "../modules/macstadium_go_worker"
+  host_id = "${module.macstadium_infrastructure.wjb_uuid}"
+  ssh_host = "${module.macstadium_infrastructure.wjb_ip}"
+  ssh_user = "${var.ssh_user}"
+  version = "${var.travis_worker_production_version}"
+  config_path = "${path.module}/config/travis-worker-production-com-xserve-1"
+  env = "production-com-xserve-1"
+  index = "${var.index}"
+}
+
+module "worker_production_com_xserve_2" {
+  source = "../modules/macstadium_go_worker"
+  host_id = "${module.macstadium_infrastructure.wjb_uuid}"
+  ssh_host = "${module.macstadium_infrastructure.wjb_ip}"
+  ssh_user = "${var.ssh_user}"
+  version = "${var.travis_worker_production_version}"
+  config_path = "${path.module}/config/travis-worker-production-com-xserve-2"
+  env = "production-com-xserve-2"
   index = "${var.index}"
 }
 
@@ -445,5 +479,12 @@ module "haproxy" {
     frontend_port = "8089"
     backend_port_blue = "9089"
     backend_port_green = "10089"
+  }
+
+  config {
+    name = "jupiter-brain-production-com-xserve"
+    frontend_port = "8090"
+    backend_port_blue = "9090"
+    backend_port_green = "10090"
   }
 }

--- a/macstadium-shared-2/Makefile
+++ b/macstadium-shared-2/Makefile
@@ -17,6 +17,7 @@ CONFIG_FILES := \
 		config/vsphere-janitor-custom-4 \
 		config/vsphere-janitor-custom-5 \
 		config/vsphere-janitor-production-com \
+		config/jupiter-brain-production-com-xserve-env \
 		config/vsphere-janitor-staging-com \
 		config/jupiter-brain-production-com-env \
 		config/jupiter-brain-staging-com-env \
@@ -24,6 +25,8 @@ CONFIG_FILES := \
 		config/travis-worker-staging-com-2 \
 		config/travis-worker-production-com-1 \
 		config/travis-worker-production-com-2 \
+		config/travis-worker-production-com-xserve-1 \
+		config/travis-worker-production-com-xserve-2 \
 		config/collectd-vsphere-common \
 		config/travis-vm-ssh-key
 
@@ -65,6 +68,8 @@ $(CONFIG_FILES):
 		| sed 's/^/export /' >config/vsphere-janitor-staging-com
 	trvs generate-config -n --pro -p JUPITER_BRAIN -f env jupiter-brain production-$(INDEX) \
 		| sed 's/^/export /' >config/jupiter-brain-production-com-env
+	trvs generate-config -n --pro -p JUPITER_BRAIN -f env jupiter-brain production-$(INDEX)-xserve \
+		| sed 's/^/export /' >config/jupiter-brain-production-com-xserve-env
 	trvs generate-config -n --pro -p JUPITER_BRAIN -f env jupiter-brain staging-$(INDEX) \
 		| sed 's/^/export /' >config/jupiter-brain-staging-com-env
 	trvs generate-config -n --pro -p TRAVIS_WORKER -f env macstadium-workers staging-$(INDEX)-1 \
@@ -75,6 +80,10 @@ $(CONFIG_FILES):
 		| sed 's/^/export /' >config/travis-worker-production-com-1
 	trvs generate-config -n --pro -p TRAVIS_WORKER -f env macstadium-workers production-$(INDEX)-2 \
 		| sed 's/^/export /' >config/travis-worker-production-com-2
+	trvs generate-config -n --pro -p TRAVIS_WORKER -f env macstadium-workers production-$(INDEX)-xserve-1 \
+		| sed 's/^/export /' >config/travis-worker-production-com-xserve-1
+	trvs generate-config -n --pro -p TRAVIS_WORKER -f env macstadium-workers production-$(INDEX)-xserve-2 \
+		| sed 's/^/export /' >config/travis-worker-production-com-xserve-2
 	trvs generate-config -n -p COLLECTD_VSPHERE -f env collectd-vsphere common-$(INDEX) \
 		| sed 's/^/export /' >config/collectd-vsphere-common
 

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -84,6 +84,18 @@ module "jupiter_brain_production_com" {
   port_suffix = 3
 }
 
+module "jupiter_brain_production_com_xserve" {
+  source = "../modules/jupiter_brain_bluegreen"
+  host_id = "${module.macstadium_infrastructure.wjb_uuid}"
+  ssh_ip_address = "${module.macstadium_infrastructure.wjb_ip}"
+  ssh_user = "${var.ssh_user}"
+  version = "${var.jupiter_brain_production_version}"
+  config_path = "${path.module}/config/jupiter-brain-production-com-xserve-env"
+  env = "production-com-xserve"
+  index = "${var.index}"
+  port_suffix = 10
+}
+
 module "jupiter_brain_staging_com" {
   source = "../modules/jupiter_brain_bluegreen"
   host_id = "${module.macstadium_infrastructure.wjb_uuid}"
@@ -183,6 +195,28 @@ module "worker_production_com_2" {
   version = "${var.travis_worker_production_version}"
   config_path = "${path.module}/config/travis-worker-production-com-2"
   env = "production-com-2"
+  index = "${var.index}"
+}
+
+module "worker_production_com_xserve_1" {
+  source = "../modules/macstadium_go_worker"
+  host_id = "${module.macstadium_infrastructure.wjb_uuid}"
+  ssh_host = "${module.macstadium_infrastructure.wjb_ip}"
+  ssh_user = "${var.ssh_user}"
+  version = "${var.travis_worker_production_version}"
+  config_path = "${path.module}/config/travis-worker-production-com-xserve-1"
+  env = "production-com-xserve-1"
+  index = "${var.index}"
+}
+
+module "worker_production_com_xserve_2" {
+  source = "../modules/macstadium_go_worker"
+  host_id = "${module.macstadium_infrastructure.wjb_uuid}"
+  ssh_host = "${module.macstadium_infrastructure.wjb_ip}"
+  ssh_user = "${var.ssh_user}"
+  version = "${var.travis_worker_production_version}"
+  config_path = "${path.module}/config/travis-worker-production-com-xserve-2"
+  env = "production-com-xserve-2"
   index = "${var.index}"
 }
 
@@ -316,5 +350,12 @@ module "haproxy" {
     frontend_port = "8089"
     backend_port_blue = "9089"
     backend_port_green = "10089"
+  }
+
+  config {
+    name = "jupiter-brain-production-com-xserve"
+    frontend_port = "8090"
+    backend_port_blue = "9090"
+    backend_port_green = "10090"
   }
 }


### PR DESCRIPTION
This allows running some capacity on the Xserve cluster in addition to the Mac Pro cluster.