### PR TITLE
Adding hardcoded OIDs to get the CPU usage

### DIFF
--- a/modules/collectd_vsphere/snmp.conf.tpl
+++ b/modules/collectd_vsphere/snmp.conf.tpl
@@ -13,6 +13,30 @@
 		Values "IF-MIB::ifHCInUcastPkts" "IF-MIB::ifHCOutUcastPkts"
 	</Data>
 
+	<Data "host_cpu0_pod1">
+		Type "cpu"
+		Table false
+		Values "iso.3.6.1.2.1.25.3.3.1.2.164"
+	</Data>
+
+	<Data "host_cpu1_pod1">
+		Type "cpu"
+		Table false
+		Values "iso.3.6.1.2.1.25.3.3.1.2.167"
+	</Data>
+
+	<Data "host_cpu0_pod2">
+		Type "cpu"
+		Table false
+		Values "iso.3.6.1.2.1.25.3.3.1.2.163"
+	</Data>
+
+	<Data "host_cpu1_pod2">
+		Type "cpu"
+		Table false
+		Values "iso.3.6.1.2.1.25.3.3.1.2.166"
+	</Data>
+
 	<Host "TravisCI-Prod-FW">
 		Address "${fw_ip}"
 		Version 2
@@ -25,7 +49,7 @@
 		Address "${pfsense_1_ip}"
 		Version 2
 		Community "${pfsense_1_snmp_community}"
-		Collect "ifmib_if_octets64" "ifmib_if_packets64"
+		Collect "ifmib_if_octets64" "ifmib_if_packets64" "host_cpu0_pod1" "host_cpu1_pod1"
 		Interval 60
 	</Host>
 
@@ -33,7 +57,7 @@
 		Address "${pfsense_2_ip}"
 		Version 2
 		Community "${pfsense_2_snmp_community}"
-		Collect "ifmib_if_octets64" "ifmib_if_packets64"
+		Collect "ifmib_if_octets64" "ifmib_if_packets64" "host_cpu0_pod1" "host_cpu1_pod1"
 		Interval 60
 	</Host>
 
@@ -41,7 +65,7 @@
 		Address "${pfsense_2_1_ip}"
 		Version 2
 		Community "${pfsense_2_1_snmp_community}"
-		Collect "ifmib_if_octets64" "ifmib_if_packets64"
+		Collect "ifmib_if_octets64" "ifmib_if_packets64" "host_cpu0_pod2" "host_cpu1_pod2"
 		Interval 60
 	</Host>
 
@@ -49,7 +73,7 @@
 		Address "${pfsense_2_2_ip}"
 		Version 2
 		Community "${pfsense_2_2_snmp_community}"
-		Collect "ifmib_if_octets64" "ifmib_if_packets64"
+		Collect "ifmib_if_octets64" "ifmib_if_packets64" "host_cpu0_pod2" "host_cpu1_pod2"
 		Interval 60
 	</Host>
 </Plugin>

--- a/modules/collectd_vsphere/snmp.conf.tpl
+++ b/modules/collectd_vsphere/snmp.conf.tpl
@@ -13,29 +13,12 @@
 		Values "IF-MIB::ifHCInUcastPkts" "IF-MIB::ifHCOutUcastPkts"
 	</Data>
 
-	<Data "host_cpu0_pod1">
-		Type "cpu"
-		Table false
-		Values "iso.3.6.1.2.1.25.3.3.1.2.164"
-	</Data>
-
-	<Data "host_cpu1_pod1">
-		Type "cpu"
-		Table false
-		Values "iso.3.6.1.2.1.25.3.3.1.2.167"
-	</Data>
-
-	<Data "host_cpu0_pod2">
-		Type "cpu"
-		Table false
-		Values "iso.3.6.1.2.1.25.3.3.1.2.163"
-	</Data>
-
-	<Data "host_cpu1_pod2">
-		Type "cpu"
-		Table false
-		Values "iso.3.6.1.2.1.25.3.3.1.2.166"
-	</Data>
+  <Data "cpu_percentage">
+    Type "percent"
+    Table true
+    Instance "HOST-RESOURCES-MIB::hrDeviceDescr"
+    Values "HOST-RESOURCES-MIB::hrProcessorLoad"
+  </Data>
 
 	<Host "TravisCI-Prod-FW">
 		Address "${fw_ip}"
@@ -49,7 +32,7 @@
 		Address "${pfsense_1_ip}"
 		Version 2
 		Community "${pfsense_1_snmp_community}"
-		Collect "ifmib_if_octets64" "ifmib_if_packets64" "host_cpu0_pod1" "host_cpu1_pod1"
+		Collect "ifmib_if_octets64" "ifmib_if_packets64" "cpu_percentage"
 		Interval 60
 	</Host>
 
@@ -57,7 +40,7 @@
 		Address "${pfsense_2_ip}"
 		Version 2
 		Community "${pfsense_2_snmp_community}"
-		Collect "ifmib_if_octets64" "ifmib_if_packets64" "host_cpu0_pod1" "host_cpu1_pod1"
+		Collect "ifmib_if_octets64" "ifmib_if_packets64" "cpu_percentage"
 		Interval 60
 	</Host>
 
@@ -65,7 +48,7 @@
 		Address "${pfsense_2_1_ip}"
 		Version 2
 		Community "${pfsense_2_1_snmp_community}"
-		Collect "ifmib_if_octets64" "ifmib_if_packets64" "host_cpu0_pod2" "host_cpu1_pod2"
+		Collect "ifmib_if_octets64" "ifmib_if_packets64" "cpu_percentage"
 		Interval 60
 	</Host>
 
@@ -73,7 +56,7 @@
 		Address "${pfsense_2_2_ip}"
 		Version 2
 		Community "${pfsense_2_2_snmp_community}"
-		Collect "ifmib_if_octets64" "ifmib_if_packets64" "host_cpu0_pod2" "host_cpu1_pod2"
+		Collect "ifmib_if_octets64" "ifmib_if_packets64" "cpu_percentage"
 		Interval 60
 	</Host>
 </Plugin>


### PR DESCRIPTION
- Specific OIDs for each CPU is defined in detail
- We'll need to see if/how we can make it more flexible

----

### How I determine what to use?

1. I determined the _base_ OID to use, `1.3.6.1.2.1.25.3.3.1.2`, from https://forums.freebsd.org/threads/41768/
2. I figured out the specific OIDs using `snmpwalk`

**pod1:**

``` shell
brandon@wjb-2:~# snmpwalk -v 2c -c [REDACTED] 10.182.64.64 1.3.6.1.2.1.25.3.3.1.2
iso.3.6.1.2.1.25.3.3.1.2.164 = INTEGER: 31
iso.3.6.1.2.1.25.3.3.1.2.167 = INTEGER: 32
```

**pod2:**

``` shell
brandon@wjb-2:~# snmpwalk -v 2c -c [REDACTED] 10.182.64.66 1.3.6.1.2.1.25.3.3.1.2
iso.3.6.1.2.1.25.3.3.1.2.163 = INTEGER: 11
iso.3.6.1.2.1.25.3.3.1.2.166 = INTEGER: 11
```