### PR TITLE
macstadium: update vsphere janitor to 0a41b7f

### DIFF
--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -15,7 +15,8 @@ variable "travis_worker_custom-4_version" { default = "v2.6.2" }
 variable "travis_worker_custom-5_version" { default = "v2.6.2" }
 variable "travis_worker_production_version" { default = "v2.6.2" }
 variable "travis_worker_staging_version" { default = "v2.6.2" }
-variable "vsphere_janitor_version" { default = "9bde41b" }
+variable "vsphere_janitor_version" { default = "0a41b7f" }
+variable "vsphere_janitor_staging_version" { default = "0a41b7f" }
 variable "collectd_vsphere_version" { default = "e1b57fe" }
 variable "ssh_user" {
   description = "your username on the wjb instances"
@@ -369,7 +370,7 @@ module "vsphere_janitor_staging_com" {
   host_id = "${module.macstadium_infrastructure.wjb_uuid}"
   ssh_host = "${module.macstadium_infrastructure.wjb_ip}"
   ssh_user = "${var.ssh_user}"
-  version = "${var.vsphere_janitor_version}"
+  version = "${var.vsphere_janitor_staging_version}"
   config_path = "${path.module}/config/vsphere-janitor-staging-com"
   env = "staging-com"
   index = "${var.index}"

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -9,7 +9,8 @@ variable "travis_worker_production_version" { default = "v2.6.2" }
 variable "travis_worker_staging_version" { default = "v2.6.2" }
 variable "travis_worker_custom-4_version" { default = "v2.6.2" }
 variable "travis_worker_custom-5_version" { default = "v2.6.2" }
-variable "vsphere_janitor_version" { default = "9bde41b" }
+variable "vsphere_janitor_version" { default = "0a41b7f" }
+variable "vsphere_janitor_staging_version" { default = "0a41b7f" }
 variable "collectd_vsphere_version" { default = "e1b57fe" }
 variable "ssh_user" {
   description = "your username on the wjb instances"
@@ -294,7 +295,7 @@ module "vsphere_janitor_staging_com" {
   host_id = "${module.macstadium_infrastructure.wjb_uuid}"
   ssh_host = "${module.macstadium_infrastructure.wjb_ip}"
   ssh_user = "${var.ssh_user}"
-  version = "${var.vsphere_janitor_version}"
+  version = "${var.vsphere_janitor_staging_version}"
   config_path = "${path.module}/config/vsphere-janitor-staging-com"
   env = "staging-com"
   index = "${var.index}"


### PR DESCRIPTION
The main diff is handling cleanup of powered off VMs.

Full diff: https://github.com/travis-ci/vsphere-janitor/compare/9bde41b...0a41b7f.