### PR TITLE
Upgrade to Terraform 0.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
     pushd "${TMPDIR}" ;
     curl -sSL
       -o terraform.zip
-      "https://releases.hashicorp.com/terraform/0.8.2/terraform_0.8.2_linux_amd64.zip" ;
+      "https://releases.hashicorp.com/terraform/0.9.0/terraform_0.9.0_linux_amd64.zip" ;
     unzip terraform.zip ;
     mv -v terraform "${HOME}/bin/terraform" ;
     chmod +x "${HOME}/bin/terraform" ;

--- a/aws-precise-production-2/main.tf
+++ b/aws-precise-production-2/main.tf
@@ -11,6 +11,15 @@ variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 variable "worker_ami" { default = "ami-a38664b5" }
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/aws-precise-production-2.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "aws" {}
 
 data "terraform_remote_state" "vpc" {

--- a/aws-precise-staging-1/main.tf
+++ b/aws-precise-staging-1/main.tf
@@ -17,6 +17,15 @@ variable "latest_docker_image_worker" {}
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/aws-precise-staging-1.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "aws" {}
 
 data "aws_ami" "worker" {

--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -10,6 +10,15 @@ variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 variable "worker_ami" { default = "ami-a38664b5" }
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/aws-production-2.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "aws" {}
 
 data "terraform_remote_state" "vpc" {

--- a/aws-shared-1/main.tf
+++ b/aws-shared-1/main.tf
@@ -16,6 +16,15 @@ variable "workers_com_subnet_1e_cidr" { default = "10.10.5.0/24" }
 variable "workers_org_subnet_1b_cidr" { default = "10.10.2.0/24" }
 variable "workers_org_subnet_1e_cidr" { default = "10.10.6.0/24" }
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/aws-shared-1.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "aws" {}
 
 data "aws_ami" "nat" {

--- a/aws-shared-2/main.tf
+++ b/aws-shared-2/main.tf
@@ -20,6 +20,15 @@ variable "workers_org_subnet_1b_cidr" { default = "10.12.2.0/24" }
 variable "workers_org_subnet_1c_cidr" { default = "10.12.9.0/24" }
 variable "workers_org_subnet_1e_cidr" { default = "10.12.6.0/24" }
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/aws-shared-2.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "aws" {}
 
 data "aws_ami" "nat" {

--- a/aws-staging-1/main.tf
+++ b/aws-staging-1/main.tf
@@ -8,6 +8,15 @@ variable "latest_docker_image_worker" {}
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/aws-staging-1.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "aws" {}
 
 data "aws_ami" "worker" {

--- a/gce-production-6/main.tf
+++ b/gce-production-6/main.tf
@@ -9,6 +9,15 @@ variable "travisci_net_external_zone_id" { default = "Z2RI61YP4UWSIO" }
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/gce-production-6.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "google" { project = "travis-ci-prod-6" }
 provider "aws" {}
 provider "heroku" {}

--- a/gce-production-7/main.tf
+++ b/gce-production-7/main.tf
@@ -9,6 +9,15 @@ variable "travisci_net_external_zone_id" { default = "Z2RI61YP4UWSIO" }
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/gce-production-7.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "google" { project = "travis-ci-prod-7" }
 provider "aws" {}
 provider "heroku" {}

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -11,6 +11,15 @@ variable "travisci_net_external_zone_id" { default = "Z2RI61YP4UWSIO" }
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/gce-staging-1.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "google" {
   project = "travis-staging-1"
 }

--- a/gce-staging-2/main.tf
+++ b/gce-staging-2/main.tf
@@ -10,6 +10,15 @@ variable "travisci_net_external_zone_id" { default = "Z2RI61YP4UWSIO" }
 variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/gce-staging-2.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "google" {
   project = "travis-staging-2"
 }

--- a/local-development-0/Makefile
+++ b/local-development-0/Makefile
@@ -1,11 +1,5 @@
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
 
-$(TFCONF): .config $(TFVARS)
-	terraform remote config \
-		-backend=local \
-		-backend-config="path=$(ENV_NAME).tfstate"
-	touch $@
-
 .PHONY: .config
 .config:
 	@echo no-op

--- a/local-development-0/main.tf
+++ b/local-development-0/main.tf
@@ -4,6 +4,12 @@ variable "rabbitmq_host" {}
 variable "rabbitmq_username" { default = "test" }
 variable "rabbitmq_vhost" { default = "/" }
 
+terraform {
+  backend "local" {
+    path = "local-development-0.tfstate"
+  }
+}
+
 module "rabbitmq_config_test" {
   source = "../modules/rabbitmq_user"
   admin_password = "${var.rabbitmq_admin_password}"

--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -41,6 +41,15 @@ variable "vsphere_password" {}
 variable "vsphere_server" {}
 variable "vsphere_ip" {}
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/macstadium-shared-1.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "aws" {
   region = "us-east-1"
 }

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -39,6 +39,15 @@ variable "vsphere_password" {}
 variable "vsphere_server" {}
 variable "vsphere_ip" {}
 
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/macstadium-shared-2.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
 provider "aws" {
   region = "us-east-1"
 }

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -5,7 +5,6 @@ ENV_TAIL ?= $(subst $(INFRA)-,,$(ENV_NAME))
 TFVARS := $(PWD)/terraform.tfvars
 TFSTATE := $(PWD)/.terraform/terraform.tfstate
 TFPLAN := $(PWD)/$(ENV_NAME).tfplan
-TFCONF := $(PWD)/.terraform/configured
 TOP := $(shell git rev-parse --show-toplevel)
 
 .PHONY: hello
@@ -31,12 +30,12 @@ plan: announce .config $(TFVARS) $(TFSTATE)
 		-module-depth=-1 \
 		-out=$(TFPLAN)
 
-$(TFSTATE): $(TFCONF)
-	terraform get
+$(TFSTATE):
+	terraform init
 
 .PHONY: clean
 clean: announce
-	$(RM) -r config $(TFVARS) $(TFCONF) $(ENV_NAME).tfvars
+	$(RM) -r config $(TFVARS) $(ENV_NAME).tfvars
 
 .PHONY: distclean
 distclean: clean

--- a/terraform.mk
+++ b/terraform.mk
@@ -1,13 +1,4 @@
 include $(shell git rev-parse --show-toplevel)/terraform-common.mk
 
-$(TFCONF): .config $(TFVARS)
-	terraform remote config \
-	    -backend=s3 \
-	    -backend-config=bucket=travis-terraform-state \
-	    -backend-config=key=terraform-config/$(ENV_NAME).tfstate \
-	    -backend-config=region=us-east-1 \
-	    -backend-config=encrypt=true
-	touch $@
-
 $(TFVARS):
 	trvs generate-config -f json terraform-config $(subst -,_,$(ENV_NAME)) >$@


### PR DESCRIPTION
See https://www.terraform.io/docs/backends/legacy-0-8.html for upgrade guide for the remote state.

**Note**: I already did the upgrade for `macstadium-shared-1`, as I didn't realize that it would immediately update the remote state as well.