### PR TITLE
Add gce-production-1 project

### DIFF
--- a/gce-production-1/Makefile
+++ b/gce-production-1/Makefile
@@ -1,0 +1,1 @@
+include $(shell git rev-parse --show-toplevel)/gce.mk

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -1,0 +1,53 @@
+variable "env" { default = "production" }
+variable "gce_bastion_image" { default = "eco-emissary-99515/bastion-1478778272" }
+variable "gce_gcloud_zone" {}
+variable "gce_heroku_org" {}
+variable "gce_worker_image" { default = "eco-emissary-99515/travis-worker-1480649763" }
+variable "github_users" {}
+variable "job_board_url" {}
+variable "travisci_net_external_zone_id" { default = "Z2RI61YP4UWSIO" }
+variable "syslog_address_com" {}
+variable "syslog_address_org" {}
+
+terraform {
+  backend "s3" {
+    bucket = "travis-terraform-state"
+    key = "terraform-config/gce-production-1.tfstate"
+    region = "us-east-1"
+    encrypt = "true"
+  }
+}
+
+provider "google" { project = "eco-emissary-99515" }
+provider "aws" {}
+provider "heroku" {}
+
+module "gce_project_1" {
+  source = "../modules/gce_project"
+  bastion_config = "${file("${path.module}/config/bastion-env")}"
+  bastion_image = "${var.gce_bastion_image}"
+  env = "${var.env}"
+  gcloud_cleanup_account_json = "${file("${path.module}/config/gce-cleanup-production-1.json")}"
+  gcloud_cleanup_job_board_url = "${var.job_board_url}"
+  gcloud_zone = "${var.gce_gcloud_zone}"
+  github_users = "${var.github_users}"
+  heroku_org = "${var.gce_heroku_org}"
+  index = "1"
+  project = "eco-emissary-99515"
+  syslog_address_com = "${var.syslog_address_com}"
+  syslog_address_org = "${var.syslog_address_org}"
+  travisci_net_external_zone_id = "${var.travisci_net_external_zone_id}"
+  worker_account_json_com = "${file("${path.module}/config/gce-workers-production-1.json")}"
+  worker_account_json_org = "${file("${path.module}/config/gce-workers-production-1.json")}"
+  worker_config_com = "${file("${path.module}/config/worker-env-com")}"
+  worker_config_org = "${file("${path.module}/config/worker-env-org")}"
+  worker_docker_self_image = "travisci/worker:v2.7.0"
+  worker_image = "${var.gce_worker_image}"
+  worker_instance_count_com = 6
+  worker_instance_count_org = 6
+
+  public_subnet_cidr_range = "10.10.1.0/24"
+  workers_subnet_cidr_range = "10.10.16.0/22"
+  build_org_subnet_cidr_range = "10.10.20.0/22"
+  build_com_subnet_cidr_range = "10.10.24.0/22"
+}

--- a/modules/gce_project/network.tf
+++ b/modules/gce_project/network.tf
@@ -9,7 +9,7 @@ output "gce_network" {
 
 resource "google_compute_subnetwork" "public" {
   name = "public"
-  ip_cidr_range = "10.10.0.0/22"
+  ip_cidr_range = "${var.public_subnet_cidr_range}"
   network = "${google_compute_network.main.self_link}"
   region = "us-central1"
 
@@ -22,7 +22,7 @@ output "gce_subnetwork_public" {
 
 resource "google_compute_subnetwork" "workers" {
   name = "workers"
-  ip_cidr_range = "10.10.4.0/22"
+  ip_cidr_range = "${var.workers_subnet_cidr_range}"
   network = "${google_compute_network.main.self_link}"
   region = "us-central1"
 
@@ -31,7 +31,7 @@ resource "google_compute_subnetwork" "workers" {
 
 resource "google_compute_subnetwork" "build_org" {
   name = "buildorg"
-  ip_cidr_range = "10.10.8.0/22"
+  ip_cidr_range = "${var.build_org_subnet_cidr_range}"
   network = "${google_compute_network.main.self_link}"
   region = "us-central1"
 
@@ -40,7 +40,7 @@ resource "google_compute_subnetwork" "build_org" {
 
 resource "google_compute_subnetwork" "build_com" {
   name = "buildcom"
-  ip_cidr_range = "10.10.12.0/22"
+  ip_cidr_range = "${var.build_com_subnet_cidr_range}"
   network = "${google_compute_network.main.self_link}"
   region = "us-central1"
 

--- a/modules/gce_project/variables.tf
+++ b/modules/gce_project/variables.tf
@@ -23,3 +23,8 @@ variable "worker_docker_self_image" { default = "travisci/worker:v2.6.2" }
 variable "worker_image" {}
 variable "worker_instance_count_com" {}
 variable "worker_instance_count_org" {}
+
+variable "public_subnet_cidr_range" { default = "10.10.0.0/22" }
+variable "workers_subnet_cidr_range" { default = "10.10.4.0/22" }
+variable "build_org_subnet_cidr_range" { default = "10.10.8.0/22" }
+variable "build_com_subnet_cidr_range" { default = "10.10.12.0/22" }


### PR DESCRIPTION
This is replacing an existing project, so some tweaking was necessary with the CIDR ranges to not conflicting with the existing networks. I made the variables have their existing values as defaults, so it should be backwards-compatible for production-6 and production-7.