### PR TITLE
Don't give up trying to restart the worker in MacStadium

### DIFF
--- a/modules/macstadium_go_worker/worker.conf.tpl
+++ b/modules/macstadium_go_worker/worker.conf.tpl
@@ -6,7 +6,7 @@ setuid travis-worker
 setgid nogroup
 
 respawn
-respawn limit 10 90
+respawn limit unlimited
 
 script
   TRAVIS_WORKER_RUN_DIR=/var/tmp/run/travis-worker


### PR DESCRIPTION
Sometimes we lose connection and it can't be done in 90 seconds so keep trying. This means that when some customers restart their server our workers sometimes lose connection to them and then give up causing their mac infrastructure to stop working. 