### PR TITLE
Bump all infra workers to v2.9.2

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -29,10 +29,6 @@ variable "garnet_image" {
   default = "travisci/ci-garnet:packer-1478744932"
 }
 
-variable "worker_image" {
-  default = "travisci/worker:v2.8.2"
-}
-
 terraform {
   backend "s3" {
     bucket  = "travis-terraform-state"
@@ -171,7 +167,6 @@ module "aws_asg_com" {
   worker_docker_image_php        = "${var.garnet_image}"
   worker_docker_image_python     = "${var.garnet_image}"
   worker_docker_image_ruby       = "${var.garnet_image}"
-  worker_docker_self_image       = "${var.worker_image}"
   worker_instance_type           = "c3.8xlarge"
   worker_queue                   = "ec2"
   worker_subnets                 = "${data.terraform_remote_state.vpc.workers_com_subnet_1b_id},${data.terraform_remote_state.vpc.workers_com_subnet_1e_id}"
@@ -218,7 +213,6 @@ module "aws_asg_org" {
   worker_docker_image_php        = "${var.garnet_image}"
   worker_docker_image_python     = "${var.garnet_image}"
   worker_docker_image_ruby       = "${var.garnet_image}"
-  worker_docker_self_image       = "${var.worker_image}"
   worker_instance_type           = "c3.8xlarge"
   worker_queue                   = "ec2"
   worker_subnets                 = "${data.terraform_remote_state.vpc.workers_org_subnet_1b_id},${data.terraform_remote_state.vpc.workers_org_subnet_1e_id}"

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -58,7 +58,6 @@ module "gce_project_1" {
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-production-1.json")}"
   worker_config_com             = "${file("${path.module}/config/worker-env-com")}"
   worker_config_org             = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_self_image      = "travisci/worker:v2.7.0"
   worker_image                  = "${var.gce_worker_image}"
   worker_instance_count_com     = 6
   worker_instance_count_org     = 6

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -58,7 +58,6 @@ module "gce_project_1" {
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-production-2.json")}"
   worker_config_com             = "${file("${path.module}/config/worker-env-com")}"
   worker_config_org             = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_self_image      = "travisci/worker:v2.7.0"
   worker_image                  = "${var.gce_worker_image}"
   worker_instance_count_com     = 6
   worker_instance_count_org     = 6

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -58,7 +58,6 @@ module "gce_project_1" {
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-production-3.json")}"
   worker_config_com             = "${file("${path.module}/config/worker-env-com")}"
   worker_config_org             = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_self_image      = "travisci/worker:v2.7.0"
   worker_image                  = "${var.gce_worker_image}"
   worker_instance_count_com     = 6
   worker_instance_count_org     = 6

--- a/gce-production-4/main.tf
+++ b/gce-production-4/main.tf
@@ -58,7 +58,6 @@ module "gce_project_1" {
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-production-4.json")}"
   worker_config_com             = "${file("${path.module}/config/worker-env-com")}"
   worker_config_org             = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_self_image      = "travisci/worker:v2.7.0"
   worker_image                  = "${var.gce_worker_image}"
   worker_instance_count_com     = 0
   worker_instance_count_org     = 12

--- a/gce-production-5/main.tf
+++ b/gce-production-5/main.tf
@@ -58,7 +58,6 @@ module "gce_project_1" {
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-production-5.json")}"
   worker_config_com             = "${file("${path.module}/config/worker-env-com")}"
   worker_config_org             = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_self_image      = "travisci/worker:v2.7.0"
   worker_image                  = "${var.gce_worker_image}"
   worker_instance_count_com     = 0
   worker_instance_count_org     = 12

--- a/gce-production-6/main.tf
+++ b/gce-production-6/main.tf
@@ -58,7 +58,6 @@ module "gce_project_6" {
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-production-6.json")}"
   worker_config_com             = "${file("${path.module}/config/worker-env-com")}"
   worker_config_org             = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_self_image      = "travisci/worker:v2.7.0"
   worker_image                  = "${var.gce_worker_image}"
   worker_instance_count_com     = 10
   worker_instance_count_org     = 0

--- a/gce-production-7/main.tf
+++ b/gce-production-7/main.tf
@@ -58,7 +58,6 @@ module "gce_project_7" {
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-production-7.json")}"
   worker_config_com             = "${file("${path.module}/config/worker-env-com")}"
   worker_config_org             = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_self_image      = "travisci/worker:v2.7.0"
   worker_image                  = "${var.gce_worker_image}"
   worker_instance_count_com     = 10
   worker_instance_count_org     = 0

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -66,7 +66,6 @@ module "gce_project_1" {
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-staging-1.json")}"
   worker_config_com             = "${file("${path.module}/config/worker-env-com")}"
   worker_config_org             = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_self_image      = "travisci/worker:v2.9.1"
   worker_image                  = "${var.gce_worker_image}"
 
   # instance count must be a multiple of number of zones (currently 2)

--- a/gce-staging-2/main.tf
+++ b/gce-staging-2/main.tf
@@ -66,7 +66,6 @@ module "gce_project_2" {
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-staging-2.json")}"
   worker_config_com             = "${file("${path.module}/config/worker-env-com")}"
   worker_config_org             = "${file("${path.module}/config/worker-env-org")}"
-  worker_docker_self_image      = "travisci/worker:v2.9.1"
   worker_image                  = "${var.gce_worker_image}"
 
   # instance count must be a multiple of number of zones (currently 2)

--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -43,35 +43,35 @@ variable "jupiter_brain_staging_version" {
 }
 
 variable "travis_worker_custom-1_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_custom-2_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_custom-3_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_custom-4_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_custom-5_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_custom-6_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_production_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_staging_version" {
-  default = "v2.9.1"
+  default = "v2.9.2"
 }
 
 variable "vsphere_janitor_version" {

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -39,31 +39,31 @@ variable "jupiter_brain_custom-5_version" {
 }
 
 variable "travis_worker_production_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_staging_version" {
-  default = "v2.9.1"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_custom-1_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_custom-2_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_custom-3_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_custom-4_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_custom-5_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "vsphere_janitor_version" {

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -99,7 +99,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v2.8.2"
+  default = "travisci/worker:v2.9.2"
 }
 
 variable "worker_instance_type" {

--- a/modules/gce_project/variables.tf
+++ b/modules/gce_project/variables.tf
@@ -35,7 +35,7 @@ variable "worker_config_com" {}
 variable "worker_config_org" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v2.6.2"
+  default = "travisci/worker:v2.9.2"
 }
 
 variable "worker_image" {}


### PR DESCRIPTION
except precise-production, which is going away soon.

Supersedes #174

I have applied this to:
- [x] gce-staging-1
- [x] aws-staging-1

- [x] gce-production-1
- [x] gce-production-2
- [x] gce-production-3
- [x] gce-production-4
- [x] gce-production-5
- [x] gce-production-6
- [x] gce-production-7
- [x] macstadium-shared-1
- [x] macstadium-shared-2