### PR TITLE
Production worker version rollback all infras

### DIFF
--- a/gce-production-5/main.tf
+++ b/gce-production-5/main.tf
@@ -60,7 +60,7 @@ module "gce_project_1" {
   worker_config_org             = "${file("${path.module}/config/worker-env-org")}"
   worker_image                  = "${var.gce_worker_image}"
   worker_instance_count_com     = 0
-  worker_instance_count_org     = 12
+  worker_instance_count_org     = 13
 
   public_subnet_cidr_range    = "10.10.1.0/24"
   workers_subnet_cidr_range   = "10.10.16.0/22"

--- a/gce-production-5/main.tf
+++ b/gce-production-5/main.tf
@@ -60,7 +60,7 @@ module "gce_project_1" {
   worker_config_org             = "${file("${path.module}/config/worker-env-org")}"
   worker_image                  = "${var.gce_worker_image}"
   worker_instance_count_com     = 0
-  worker_instance_count_org     = 13
+  worker_instance_count_org     = 14
 
   public_subnet_cidr_range    = "10.10.1.0/24"
   workers_subnet_cidr_range   = "10.10.16.0/22"

--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -43,35 +43,35 @@ variable "jupiter_brain_staging_version" {
 }
 
 variable "travis_worker_custom-1_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_custom-2_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_custom-3_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_custom-4_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_custom-5_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_custom-6_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_production_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_staging_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "vsphere_janitor_version" {

--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -71,7 +71,7 @@ variable "travis_worker_production_version" {
 }
 
 variable "travis_worker_staging_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "vsphere_janitor_version" {

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -43,7 +43,7 @@ variable "travis_worker_production_version" {
 }
 
 variable "travis_worker_staging_version" {
-  default = "v2.6.2"
+  default = "v2.9.2"
 }
 
 variable "travis_worker_custom-1_version" {

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -39,31 +39,31 @@ variable "jupiter_brain_custom-5_version" {
 }
 
 variable "travis_worker_production_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_staging_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_custom-1_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_custom-2_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_custom-3_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_custom-4_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "travis_worker_custom-5_version" {
-  default = "v2.9.2"
+  default = "v2.6.2"
 }
 
 variable "vsphere_janitor_version" {

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -99,7 +99,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v2.9.2"
+  default = "travisci/worker:v2.8.2"
 }
 
 variable "worker_instance_type" {

--- a/modules/gce_project/variables.tf
+++ b/modules/gce_project/variables.tf
@@ -35,7 +35,7 @@ variable "worker_config_com" {}
 variable "worker_config_org" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v2.9.2"
+  default = "travisci/worker:v2.7.0"
 }
 
 variable "worker_image" {}


### PR DESCRIPTION
I have already applied this, including directly patching and restarting GCE instances.

**Update**: I have added 2 more instances on gce-production-5 and manually altered their configs to include:

``` bash
export TRAVIS_WORKER_POOL_SIZE=2
export TRAVIS_WORKER_SELF_IMAGE="travisci/worker:v2.9.2"
```