### PR TITLE
Bump all infrastructures to worker v2.9.3

### DIFF
--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -43,35 +43,35 @@ variable "jupiter_brain_staging_version" {
 }
 
 variable "travis_worker_custom-1_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_custom-2_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_custom-3_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_custom-4_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_custom-5_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_custom-6_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_production_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_staging_version" {
-  default = "v2.9.2"
+  default = "v2.9.3"
 }
 
 variable "vsphere_janitor_version" {

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -39,31 +39,31 @@ variable "jupiter_brain_custom-5_version" {
 }
 
 variable "travis_worker_production_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_staging_version" {
-  default = "v2.9.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_custom-1_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_custom-2_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_custom-3_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_custom-4_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "travis_worker_custom-5_version" {
-  default = "v2.6.2"
+  default = "v2.9.3"
 }
 
 variable "vsphere_janitor_version" {

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -99,7 +99,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v2.8.2"
+  default = "travisci/worker:v2.9.3"
 }
 
 variable "worker_instance_type" {

--- a/modules/gce_project/variables.tf
+++ b/modules/gce_project/variables.tf
@@ -35,7 +35,7 @@ variable "worker_config_com" {}
 variable "worker_config_org" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v2.7.0"
+  default = "travisci/worker:v2.9.3"
 }
 
 variable "worker_image" {}


### PR DESCRIPTION
Applied on:
- [x] macstadium-shared-1
- [x] macstadium-shared-2
- [x] gce-production-1
- [x] gce-production-2
- [x] gce-production-3
- [x] gce-production-4
- [x] gce-production-5
- [x] gce-production-6
- [x] gce-production-7
- [x] aws-production-2