### PR TITLE
Set the fs.aio-max-nr on travis-worker hosts

### DIFF
--- a/modules/aws_asg/bats_helpers.bash
+++ b/modules/aws_asg/bats_helpers.bash
@@ -52,9 +52,10 @@ EOF
     iptables \
     sed \
     service \
-    systemctl \
     shutdown \
-    sleep; do
+    sleep \
+    sysctl \
+    systemctl; do
     pushd "${BATS_TMPDIR}/bin" &>/dev/null
     ln -svf mock "${cmd}"
     popd &>/dev/null

--- a/modules/aws_asg/cloud-init.bash
+++ b/modules/aws_asg/cloud-init.bash
@@ -16,6 +16,8 @@ main() {
     sed -i "s/___INSTANCE_ID___/${instance_id}/g" "${envfile}"
   done
 
+  __set_aio_max_nr
+
   chown -R travis:travis "${RUNDIR}"
 
   if [[ -d "${ETCDIR}/systemd/system" ]]; then
@@ -58,6 +60,14 @@ __wait_for_docker() {
     sleep 10
     let i+=10
   done
+}
+
+__set_aio_max_nr() {
+  # NOTE: we do this mostly to ensure file IO chatty services like mysql will
+  # play nicely with others, such as when multiple containers are running mysql,
+  # which is the default on precise + trusty.  The value we set here is 16^5,
+  # which is one power higher than the default of 16^4 :sparkles:.
+  sysctl -w fs.aio-max-nr=1048576
 }
 
 main "$@"


### PR DESCRIPTION
at cloud-init time for purposes of addressing issues with running MySQL
across all containers in an instance.

Signed-off-by: Carmen Andoh <carmen@travis-ci.org>