### PR TITLE
Add 'make check' to verify a few common setup requirements

### DIFF
--- a/bin/check-credentials
+++ b/bin/check-credentials
@@ -6,38 +6,37 @@ die() {
 }
 
 stderr_echo() {
-  >&2 echo "$@"
+  echo >&2 "$@"
 }
 
 check_heroku() {
-    endpoints="
-        travis-pro-web-staging
+  endpoints="
+        travis-pro-staging
         travis-staging
     "
-    stderr_echo "Attempting to authenticate with Heroku..."
-    for endpoint in $endpoints; do
-        cmd="curl --silent \
+  stderr_echo "Attempting to authenticate with Heroku..."
+  for endpoint in $endpoints; do
+    cmd="curl --silent \
             --output /dev/null \
             --write-out '%{http_code}' \
             -H 'Authorization: Bearer $HEROKU_API_KEY' \
             -H 'Content-Type: application/json' \
             -H 'Accept: application/vnd.heroku+json; version=3' \
             https://api.heroku.com/apps/${endpoint}/config-vars"
-        status_code=$(eval "$cmd")
+    status_code=$(eval "$cmd")
 
-        if test "$status_code" -eq 200; then
-            stderr_echo " [OK] Heroku: $endpoint"
-        else
-            die "[NOK] Got status code ${status_code} when attempting to authenticate with Heroku (${endpoint})!
+    if test "$status_code" -eq 200; then
+      stderr_echo " [OK] Heroku: $endpoint"
+    else
+      die "[NOK] Got status code ${status_code} when attempting to authenticate with Heroku (${endpoint})!
             This is the command I ran to check:
             $cmd"
-        fi
-    done
+    fi
+  done
 }
 
-
 check_envvars() {
-    ENVVARS="
+  ENVVARS="
         HEROKU_API_KEY
         GITHUB_TOKEN
         GITHUB_USERNAME
@@ -46,25 +45,24 @@ check_envvars() {
         AWS_REGION
     "
 
-    STATUS=0
-    for envvar in $ENVVARS; do
-        
-        # ensure no TF_VAR_* environment variables are present
-        tf_envvar="TF_VAR_${envvar}"
-        [ ! -z "${!tf_envvar}" ] && die "Please unset environment variable ${tf_envvar}"
+  STATUS=0
+  for envvar in $ENVVARS; do
 
-        if [ -z "${!envvar}" ]; then
-            echo "Please set environment variable $envvar."
-            STATUS=1
-        fi
-    done
-    return $STATUS
+    # ensure no TF_VAR_* environment variables are present
+    tf_envvar="TF_VAR_${envvar}"
+    [ ! -z "${!tf_envvar}" ] && die "Please unset environment variable ${tf_envvar}"
+
+    if [ -z "${!envvar}" ]; then
+      echo "Please set environment variable $envvar."
+      STATUS=1
+    fi
+  done
+  return $STATUS
 }
 
-
 main() {
-    check_envvars && stderr_echo " [OK] Envvars"
-    check_heroku && stderr_echo " [OK] Heroku"
+  check_envvars && stderr_echo " [OK] Envvars"
+  check_heroku && stderr_echo " [OK] Heroku"
 }
 
 main "$@"

--- a/bin/check-credentials
+++ b/bin/check-credentials
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -o errexit
+
+die() {
+  stderr_echo "$@" && exit 1
+}
+
+stderr_echo() {
+  >&2 echo "$@"
+}
+
+check_heroku() {
+    endpoints="
+        travis-pro-web-staging
+        travis-staging
+    "
+    stderr_echo "Attempting to authenticate with Heroku..."
+    for endpoint in $endpoints; do
+        cmd="curl --silent \
+            --output /dev/null \
+            --write-out '%{http_code}' \
+            -H 'Authorization: Bearer $HEROKU_API_KEY' \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/vnd.heroku+json; version=3' \
+            https://api.heroku.com/apps/${endpoint}/config-vars"
+        status_code=$(eval "$cmd")
+
+        if test "$status_code" -eq 200; then
+            stderr_echo " [OK] Heroku: $endpoint"
+        else
+            die "[NOK] Got status code ${status_code} when attempting to authenticate with Heroku (${endpoint})!
+            This is the command I ran to check:
+            $cmd"
+        fi
+    done
+}
+
+
+check_envvars() {
+    ENVVARS="
+        HEROKU_API_KEY
+        GITHUB_TOKEN
+        GITHUB_USERNAME
+        AWS_ACCESS_KEY
+        AWS_SECRET_KEY
+        AWS_REGION
+    "
+
+    STATUS=0
+    for envvar in $ENVVARS; do
+        
+        # ensure no TF_VAR_* environment variables are present
+        tf_envvar="TF_VAR_${envvar}"
+        [ ! -z "${!tf_envvar}" ] && die "Please unset environment variable ${tf_envvar}"
+
+        if [ -z "${!envvar}" ]; then
+            echo "Please set environment variable $envvar."
+            STATUS=1
+        fi
+    done
+    return $STATUS
+}
+
+
+main() {
+    check_envvars && stderr_echo " [OK] Envvars"
+    check_heroku && stderr_echo " [OK] Heroku"
+}
+
+main "$@"

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -57,6 +57,9 @@ graph:
 $(ENV_NAME).tfvars:
 	$(TOP)/bin/generate-tfvars $@
 
+.PHONY: list
+list:
+	 @$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
 
 .PHONY: check
 check:

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -56,3 +56,8 @@ graph:
 
 $(ENV_NAME).tfvars:
 	$(TOP)/bin/generate-tfvars $@
+
+
+.PHONY: check
+check:
+	$(TOP)/bin/check-credentials $@


### PR DESCRIPTION
After running into a couple of hangups getting to `make plan`, I thought it might be helpful to add a `make check` target to verify some required envvars and credentials.

Thoughts?