### PR TITLE
Abort if checks fail

### DIFF
--- a/bin/pre-flight-checks
+++ b/bin/pre-flight-checks
@@ -35,14 +35,31 @@ check_heroku() {
   done
 }
 
+DEPENDENCIES="
+  jq
+  terraform
+  trvs
+"
+check_dependencies() {
+  STATUS=0
+  for dependency in $DEPENDENCIES; do
+    if ! command -v "$dependency" >/dev/null; then
+      echo "Could not find dependency $dependency."
+      STATUS=1
+    fi
+  done
+  return $STATUS
+}
+
 check_envvars() {
   ENVVARS="
-        HEROKU_API_KEY
-        GITHUB_TOKEN
-        GITHUB_USERNAME
         AWS_ACCESS_KEY
         AWS_SECRET_KEY
         AWS_REGION
+        GITHUB_TOKEN
+        GITHUB_USERNAME
+        HEROKU_API_KEY
+        TRAVIS_KEYCHAIN_DIR
     "
 
   STATUS=0
@@ -61,7 +78,8 @@ check_envvars() {
 }
 
 main() {
-  check_envvars && stderr_echo " [OK] Envvars"
+  check_dependencies || die "Aborting; see errors above." && stderr_echo " [OK] Dependencies"
+  check_envvars || die "Aborting; see errors above." && stderr_echo " [OK] Envvars"
   check_heroku && stderr_echo " [OK] Heroku"
 }
 

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -63,4 +63,4 @@ list:
 
 .PHONY: check
 check:
-	$(TOP)/bin/check-credentials $@
+	$(TOP)/bin/pre-flight-checks $@


### PR DESCRIPTION
With this change, `make check` should:

### immediately abort if any dependencies are missing

```
$ make check
/home/aj/git/travis/terraform-config/bin/pre-flight-checks check
Could not find dependency jq.
Aborting; see errors above.
```

### immediately abort if any required environment variables are missing

If `HEROKU_API_KEY` is unset:
```
$ HEROKU_API_KEY= make check
/home/aj/git/travis/terraform-config/bin/pre-flight-checks check
 [OK] Dependencies
Please set environment variable HEROKU_API_KEY.
Aborting; see errors above.
```

If `HEROKU_API_KEY` is incorrect:
```
$ HEROKU_API_KEY=foo make check
/home/aj/git/travis/terraform-config/bin/pre-flight-checks check
 [OK] Dependencies
 [OK] Envvars
Attempting to authenticate with Heroku...
[NOK] Got status code 401 when attempting to authenticate with Heroku (travis-pro-staging)!
            This is the command I ran to check:
            curl --silent             --output /dev/null             --write-out '%{http_code}'             -H 'Authorization: Bearer foo'             -H 'Content-Type: application/json'             -H 'Accept: application/vnd.heroku+json; version=3'             https://api.heroku.com/apps/travis-pro-staging/config-vars
```

When everything is OK:
```
$ make check
/home/aj/git/travis/terraform-config/bin/pre-flight-checks check
 [OK] Dependencies
 [OK] Envvars
Attempting to authenticate with Heroku...
 [OK] Heroku: travis-pro-staging
 [OK] Heroku: travis-staging
 [OK] Heroku
```