### PR TITLE
Enable automatic state locking

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -32,10 +32,11 @@ variable "garnet_image" {
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/aws-production-2.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/aws-production-2.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 
@@ -45,9 +46,10 @@ data "terraform_remote_state" "vpc" {
   backend = "s3"
 
   config {
-    bucket = "travis-terraform-state"
-    key    = "terraform-config/aws-shared-2.tfstate"
-    region = "us-east-1"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/aws-shared-2.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/aws-staging-1/main.tf
+++ b/aws-staging-1/main.tf
@@ -18,10 +18,11 @@ variable "syslog_address_org" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/aws-staging-1.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/aws-staging-1.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 
@@ -47,9 +48,10 @@ data "terraform_remote_state" "vpc" {
   backend = "s3"
 
   config {
-    bucket = "travis-terraform-state"
-    key    = "terraform-config/aws-shared-1.tfstate"
-    region = "us-east-1"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/aws-shared-1.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/docs/aws-iam-policy.json
+++ b/docs/aws-iam-policy.json
@@ -46,6 +46,15 @@
                 "arn:aws:iam::341288657826:user/registry-shared-1",
                 "arn:aws:iam::*:user/cyclist-*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:*"
+            ],
+            "Resource": [
+                "arn:aws:dynamodb:us-east-1:341288657826:table/travis-terraform-state"
+            ]
         }
     ]
 }

--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -25,10 +25,11 @@ variable "syslog_address_org" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/gce-production-1.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-production-1.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -25,10 +25,11 @@ variable "syslog_address_org" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/gce-production-2.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-production-2.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -25,10 +25,11 @@ variable "syslog_address_org" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/gce-production-3.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-production-3.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/gce-production-4/main.tf
+++ b/gce-production-4/main.tf
@@ -25,10 +25,11 @@ variable "syslog_address_org" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/gce-production-4.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-production-4.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/gce-production-5/main.tf
+++ b/gce-production-5/main.tf
@@ -25,10 +25,11 @@ variable "syslog_address_org" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/gce-production-5.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-production-5.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/gce-production-6/main.tf
+++ b/gce-production-6/main.tf
@@ -25,10 +25,11 @@ variable "syslog_address_org" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/gce-production-6.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-production-6.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/gce-production-7/main.tf
+++ b/gce-production-7/main.tf
@@ -25,10 +25,11 @@ variable "syslog_address_org" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/gce-production-7.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-production-7.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/gce-staging-1/main.tf
+++ b/gce-staging-1/main.tf
@@ -32,10 +32,11 @@ variable "latest_docker_image_worker" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/gce-staging-1.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-staging-1.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/gce-staging-2/main.tf
+++ b/gce-staging-2/main.tf
@@ -32,10 +32,11 @@ variable "latest_docker_image_worker" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/gce-staging-2.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/gce-staging-2.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -116,10 +116,11 @@ variable "vsphere_ip" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/macstadium-shared-1.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/macstadium-shared-1.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -108,10 +108,11 @@ variable "vsphere_ip" {}
 
 terraform {
   backend "s3" {
-    bucket  = "travis-terraform-state"
-    key     = "terraform-config/macstadium-shared-2.tfstate"
-    region  = "us-east-1"
-    encrypt = "true"
+    bucket         = "travis-terraform-state"
+    key            = "terraform-config/macstadium-shared-2.tfstate"
+    region         = "us-east-1"
+    encrypt        = "true"
+    dynamodb_table = "travis-terraform-state"
   }
 }
 


### PR DESCRIPTION
This change will enable automatic locking of the Terraform remote state files by adding `dynamodb_table = "travis-terraform-state"` to all relevant backend configs.

## Action needed

This change will cause a required backend reconfiguration (i.e. `make distclean`). 

Also, IAM policy changes will be required for users who have not allowed `dynamodb:putItem` and `dynamodb:getItem` (see required policy addition [here](https://github.com/travis-infrastructure/terraform-config/pull/205/files#diff-e82dbd6efa312c22b7a6e8eb2a4bca7a)).

## Workflow change

Before, state files were not automatically locked; developers had to coordinate among themselves to avoid concurrent operations.

If this change is accepted, concurrent attempts to `plan`, `apply`, etc will result in the (non-lock-holding) users receiving a message such as the following:

```
$ make plan
[...]
Acquiring state lock. This may take a few moments...
Error locking state: Error acquiring the state lock: ConditionalCheckFailedException: The conditional request failed
	status code: 400, request id: TMO6HMF1SLG3DE0KCEDIIIRRVVVV4KQNSO5AEMVJF66Q9ASUAAJG
Lock Info:
  ID:        ba800c77-4a0d-3657-76ee-71ea81a5a880
  Path:      travis-terraform-state/terraform-config/gce-staging-1.tfstate
  Operation: OperationTypePlan
  Who:       igor@gopher.local
  Version:   0.10.0
  Created:   2017-08-09 15:18:50.736590811 +0000 UTC
  Info:      


Terraform acquires a state lock to protect the state from being written
by multiple users at the same time. Please resolve the issue above and try
again. For most commands, you can disable locking with the "-lock=false"
flag, but this is not recommended.
/home/aj/git/travis/terraform-config/terraform-common.mk:27: recipe for target 'plan' failed
make: *** [plan] Error 1
```

## How to test

- Find a buddy, and run `make plan` at the same time as them. You should see `Acquiring state lock. This may take a few moments...` in the output of `make plan`. One of you should an error like the one above (`Error locking state: Error acquiring the state lock`).
*OR*
- Open the [AWS DynamoDB console](https://console.aws.amazon.com/dynamodb/home?region=us-east-1#tables:selected=travis-terraform-state), select the **Items** tab, run `make plan` and ensure a `LockID` item (e.g. `travis-terraform-state/terraform-config/gce-staging-1.tfstate`) appears.

Resolves #200 