### PR TITLE
Make `make check` check more things

### DIFF
--- a/bin/pre-flight-checks
+++ b/bin/pre-flight-checks
@@ -9,6 +9,26 @@ stderr_echo() {
   echo >&2 "$@"
 }
 
+check_github() {
+  echo "Attempting to authenticate with GitHub..."
+  : "${GITHUB_ORG:=travis-infrastructure}"
+  : "${GITHUB_TEAM:=2420497}"
+
+  auth="${GITHUB_USERNAME}:${GITHUB_TOKEN}"
+  cmd="curl --silent \
+    --output /dev/null \
+    --write-out '%{http_code}' \
+    https://${auth}@api.github.com/teams/${GITHUB_TEAM}/members"
+  status_code=$(eval "$cmd")
+  if test "$status_code" -eq 200; then
+    stderr_echo " [OK] GitHub"
+  else
+    die "[NOK] GitHub: Got status code ${status_code} when attempting to authenticate!
+          This is the command I ran to check:
+          $cmd"
+  fi
+}
+
 check_heroku() {
   endpoints="
         travis-pro-staging
@@ -39,12 +59,15 @@ DEPENDENCIES="
   jq
   terraform
   trvs
+  shfmt
+  shellcheck
+  bats
 "
 check_dependencies() {
   STATUS=0
   for dependency in $DEPENDENCIES; do
     if ! command -v "$dependency" >/dev/null; then
-      echo "Could not find dependency $dependency."
+      echo "[NOK] Could not find dependency $dependency."
       STATUS=1
     fi
   done
@@ -80,6 +103,7 @@ check_envvars() {
 main() {
   check_dependencies || die "Aborting; see errors above." && stderr_echo " [OK] Dependencies"
   check_envvars || die "Aborting; see errors above." && stderr_echo " [OK] Envvars"
+  check_github && stderr_echo " [OK] GitHub"
   check_heroku && stderr_echo " [OK] Heroku"
 }
 

--- a/runtests
+++ b/runtests
@@ -5,7 +5,8 @@ set -o pipefail
 
 main() {
   # abort if there are uncommitted local changes
-  git diff-index --quiet HEAD -- || (echo "You have uncommitted changes. Not proceeding, as this script changes some files in place." && exit 1)
+  msg="You have uncommitted changes. Not proceeding, as this script changes some files in place."
+  git diff-index --quiet HEAD -- || (echo "$msg" && exit 1)
 
   if [[ $# -gt 1 && $1 == --env ]]; then
     echo "Running isolated with env ${2}"

--- a/runtests
+++ b/runtests
@@ -4,6 +4,9 @@ set -o errexit
 set -o pipefail
 
 main() {
+  # abort if there are uncommitted local changes
+  git diff-index --quiet HEAD -- || (echo "You have uncommitted changes. Not proceeding, as this script changes some files in place." && exit 1)
+
   if [[ $# -gt 1 && $1 == --env ]]; then
     echo "Running isolated with env ${2}"
     exec env -i \


### PR DESCRIPTION
Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?

- Some issues can cause silent or unclear failures (such as GitHub authentication issues and missing dependencies).
- Running `./runtests` causes some files to be rewritten; this is fine within a travis job but annoying when running locally if you have uncommitted changes.
 
2. What approach did you choose and why?

- Adding `check_github` to `bin/pre-flight-checks` which is called by `make check`.
- Prevent `./runtests` from running if there are uncommitted changes

3. How can you test this?

- Run: `GITHUB_TOKEN=foo make check` (within an environment subdirectory)
- Run `./runtests` locally with and without uncommitted changes; the former should abort while the latter should proceed (`git checkout .` do reset local working tree)

(4. What feedback would you like?)

- if it works for you (and if not, what goes wrong)
- if you think it's merge-worthy