### PR TITLE
Identify shell files more classily

### DIFF
--- a/runtests
+++ b/runtests
@@ -31,13 +31,11 @@ main() {
   done
 
   echo 'Running shellcheck'
-  git grep -l '^#!/usr/bin/env bash' | xargs shellcheck
-  # Temporarily disable shellcheck checks for SC2154 (undefined variable) on /bin/bash files
-  git grep -l '^#!/bin/bash' | xargs shellcheck -e SC2154
+  # Note: shellcheck checks for SC2154 (undefined variable) are disabled by '-e SC2154' below
+  git grep -El '^#!/.+\b(bash|sh)\b' | xargs shellcheck -e SC2154
 
   echo 'Running shfmt'
-  git grep -l '^#!/usr/bin/env bash' | xargs shfmt -i 2 -w
-  git grep -l '^#!/bin/bash' | xargs shfmt -i 2 -w
+  git grep -El '^#!/.+\b(bash|sh)\b' | xargs shfmt -i 2 -w
 
   echo 'Running bats'
   for f in $(git ls-files '*.bats'); do


### PR DESCRIPTION
Please make sure you cover the following points:

1. What is the problem that this PR is trying to fix?

Resolves #185 

2. What approach did you choose and why?

Use extended regex to check for shell files (as suggested by @edmorley)

3. How can you test this?

Run `./runtests` or `git grep -El '^#!/.+\b(bash|sh)\b'` in the repo root to view files identified as bash.

(4. What feedback would you like?)
