### PR TITLE
Bump the amethyst and garnet docker images for build env update

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -23,11 +23,11 @@ variable "worker_ami" {
 }
 
 variable "amethyst_image" {
-  default = "travisci/ci-amethyst:packer-1499451985"
+  default = "travisci/ci-amethyst:packer-1503974220"
 }
 
 variable "garnet_image" {
-  default = "travisci/ci-garnet:packer-1499451976"
+  default = "travisci/ci-garnet:packer-1503972846"
 }
 
 terraform {


### PR DESCRIPTION
Signed-off-by: Dan Buch <dan@travis-ci.org>

As announced via https://blog.travis-ci.com/2017-08-29-trusty-image-updates and https://docs.travis-ci.com/user/build-environment-updates/2017-09-06/.