### PR TITLE
Reduce worker_asg_scale_out_qty

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -150,7 +150,7 @@ module "aws_asg_com" {
   worker_asg_scale_in_evaluation_periods = 3
   worker_asg_scale_in_period             = 300
   worker_asg_scale_out_threshold         = 80
-  worker_asg_scale_out_qty               = 6
+  worker_asg_scale_out_qty               = 4
   worker_config                          = "${data.template_file.worker_config_com.rendered}"
   worker_docker_image_android            = "${var.amethyst_image}"
   worker_docker_image_default            = "${var.garnet_image}"
@@ -189,7 +189,7 @@ module "aws_asg_org" {
   worker_asg_scale_in_evaluation_periods = 3
   worker_asg_scale_in_period             = 300
   worker_asg_scale_out_threshold         = 60
-  worker_asg_scale_out_qty               = 6
+  worker_asg_scale_out_qty               = 4
   worker_config                          = "${data.template_file.worker_config_org.rendered}"
   worker_docker_image_android            = "${var.amethyst_image}"
   worker_docker_image_default            = "${var.garnet_image}"

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -306,9 +306,17 @@ resource "aws_autoscaling_policy" "workers_remove_capacity" {
   estimated_instance_warmup = "${var.worker_asg_scale_in_cooldown}"
   metric_aggregation_type   = "Maximum"
 
+  # Headroom is just above scale-in threshold; remove n instances
   step_adjustment {
     scaling_adjustment          = "${var.worker_asg_scale_in_qty}"
     metric_interval_lower_bound = 1.0
+    metric_interval_upper_bound = "${floor(var.worker_asg_scale_in_threshold / 2)}"
+  }
+
+  # Headroom is way above scale-in threshold; remove n * 2 instances
+  step_adjustment {
+    scaling_adjustment          = "${var.worker_asg_scale_in_qty * 2}"
+    metric_interval_lower_bound = "${floor(var.worker_asg_scale_in_threshold / 2)}"
   }
 }
 


### PR DESCRIPTION
This PR:
* reduces `worker_asg_scale_out_qty` from 6 to 4, since step scaling has a built-in multiplier now.
* adds step multiplier to scale-in to remove twice as many instances if our headroom is far enough above the threshold.

## What is the problem that this PR is trying to fix?

In the past we've been a little generous in our `worker_asg_scale_out_qty` because:
* we could only define a single action (to scale out by `n` instances) to be executed once our headroom fell below a certain threshold, and
* backlog buildup was exacerbated by the fact that a scale-in, which could take up to 2 hours, blocked scale-out actions.

With step scaling, we can create different quantities of instances based on how far below the threshold we are, and scale-in actions no longer block scale-out actions.

## What feedback would you like, if any?

Can you think of any reason this would cause problems?