### PR TITLE
Increase org worker capacity on gce-production-1

### DIFF
--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -61,7 +61,7 @@ module "gce_project_1" {
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-production-1.json")}"
   worker_image                  = "${var.gce_worker_image}"
   worker_instance_count_com     = 12
-  worker_instance_count_org     = 16
+  worker_instance_count_org     = 40
 
   public_subnet_cidr_range    = "10.10.1.0/24"
   workers_subnet_cidr_range   = "10.10.16.0/22"
@@ -85,7 +85,7 @@ ${file("${path.module}/worker.env")}
 ### config/worker-env-org
 ${file("${path.module}/config/worker-env-org")}
 
-export TRAVIS_WORKER_POOL_SIZE=30
+export TRAVIS_WORKER_POOL_SIZE=15
 export TRAVIS_WORKER_GCE_SUBNETWORK=buildorg
 export TRAVIS_WORKER_TRAVIS_SITE=org
 EOF


### PR DESCRIPTION
while also reducing per-worker pool size to decrease disruption of
individual worker restarts.

## What is the problem that this PR is trying to fix?

We currently have a backlog on our production GCE org infrastructure, and while we don't understand exactly why it's happening, we have decided that increasing worker capacity is a reasonable option.

## What approach did you choose and why?

See title and desc at top.

## How can you test this?

Roll it out :boom: