### PR TITLE
Send a Slack notification when someone runs apply or destroy

### DIFF
--- a/bin/post-flight
+++ b/bin/post-flight
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+[ -z "${SLACK_WEBHOOK}" ] && echo "Please export SLACK_WEBHOOK environment variable" && exit 1
+
+workdir="$(pwd)"
+cmd="$(ps -o args= $PPID)"
+git_info="$(cat $1/.git/FETCH_HEAD | tr '\t' ' ')"
+git_diff="$(git diff --name-only ${workdir})"
+
+echo "Sending Slack notification... "
+curl -X POST --data-urlencode \
+    'payload={"channel": "#infra-terraform", "username": "terraform-config", "text": "*terraform action /!\\*
+    user `'"${USER}"'` ran `'"${cmd}"'` in `'"$(basename ${workdir})"'`
+    on: `'"${git_info}"'`
+    any dirty files will be listed below: ``` '"${git_diff}"'```
+    ","icon_emoji":":computer:"}' "${SLACK_WEBHOOK}"

--- a/bin/post-flight
+++ b/bin/post-flight
@@ -4,13 +4,13 @@
 
 workdir="$(pwd)"
 cmd="$(ps -o args= $PPID)"
-git_info=$(tr '\t' ' ' < "$1/.git/FETCH_HEAD")
+git_info=$(tr '\t' ' ' <"$1/.git/FETCH_HEAD")
 git_diff=$(git diff --name-only "${workdir}")
 
 echo "Sending Slack notification... "
 # shellcheck disable=2016 disable=2086
 curl -X POST --data-urlencode \
-    'payload={"channel": "#infra-terraform", "username": "terraform-config", "text": "*terraform action /!\\*
+  'payload={"channel": "#infra-terraform", "username": "terraform-config", "text": "*terraform action /!\\*
     user `'"${USER}"'` ran `'"${cmd}"'` in `'"$(basename ${workdir})"'`
     on: `'"${git_info}"'`
     any dirty files will be listed below: ``` '"${git_diff}"'```

--- a/bin/post-flight
+++ b/bin/post-flight
@@ -4,10 +4,11 @@
 
 workdir="$(pwd)"
 cmd="$(ps -o args= $PPID)"
-git_info="$(cat $1/.git/FETCH_HEAD | tr '\t' ' ')"
-git_diff="$(git diff --name-only ${workdir})"
+git_info=$(tr '\t' ' ' < "$1/.git/FETCH_HEAD")
+git_diff=$(git diff --name-only "${workdir}")
 
 echo "Sending Slack notification... "
+# shellcheck disable=2016 disable=2086
 curl -X POST --data-urlencode \
     'payload={"channel": "#infra-terraform", "username": "terraform-config", "text": "*terraform action /!\\*
     user `'"${USER}"'` ran `'"${cmd}"'` in `'"$(basename ${workdir})"'`

--- a/terraform-common.mk
+++ b/terraform-common.mk
@@ -25,6 +25,7 @@ announce: checkversion
 .PHONY: apply
 apply: announce .config $(TFVARS) $(TFSTATE)
 	terraform apply $(TFPLAN)
+	$(TOP)/bin/post-flight $(TOP)
 
 .PHONY: plan
 plan: announce .config $(TFVARS) $(TFSTATE)
@@ -42,6 +43,7 @@ destroy: announce .config $(TFVARS) $(TFSTATE)
 		-module-depth=-1 \
 		-destroy \
 		-out=$(TFPLAN)
+	$(TOP)/bin/post-flight $(TOP)
 
 $(TFSTATE):
 	terraform init


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

This change addresses the lack of visibility when someone applies changes via Terraform.

## What approach did you choose and why?

A script, `bin/post-flight`, which uses `SLACK_WEBHOOK` environment variable to send a notification to the `#infra-terraform` Slack channel.

## How can you test this?

By exporting `SLACK_WEBHOOK` and running `make apply` somewhere sane.

## What feedback would you like, if any?

This currently expects a `SLACK_WEBHOOK` URL retrieved from one's personal Slack account.
I imagine there's a more generic solution involving shared credentials, but I'm not sure where to define or fetch them.