### PR TITLE
Expand aws-production-2 to all us-east-1 AZs

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -111,10 +111,28 @@ export TRAVIS_WORKER_TRAVIS_SITE=org
 EOF
 }
 
+module "aws_az_1a" {
+  source                    = "../modules/aws_workers_az"
+  az                        = "1a"
+  bastion_security_group_id = "${data.terraform_remote_state.vpc.bastion_security_group_1a_id}"
+  env                       = "${var.env}"
+  index                     = "${var.index}"
+  vpc_id                    = "${data.terraform_remote_state.vpc.vpc_id}"
+}
+
 module "aws_az_1b" {
   source                    = "../modules/aws_workers_az"
   az                        = "1b"
   bastion_security_group_id = "${data.terraform_remote_state.vpc.bastion_security_group_1b_id}"
+  env                       = "${var.env}"
+  index                     = "${var.index}"
+  vpc_id                    = "${data.terraform_remote_state.vpc.vpc_id}"
+}
+
+module "aws_az_1c" {
+  source                    = "../modules/aws_workers_az"
+  az                        = "1c"
+  bastion_security_group_id = "${data.terraform_remote_state.vpc.bastion_security_group_1c_id}"
   env                       = "${var.env}"
   index                     = "${var.index}"
   vpc_id                    = "${data.terraform_remote_state.vpc.vpc_id}"
@@ -139,7 +157,7 @@ module "aws_asg_com" {
   github_users                           = "${var.github_users}"
   heroku_org                             = "${var.aws_heroku_org}"
   index                                  = "${var.index}"
-  security_groups                        = "${module.aws_az_1b.workers_com_security_group_id},${module.aws_az_1e.workers_com_security_group_id}"
+  security_groups                        = "${module.aws_az_1a.workers_com_security_group_id},${module.aws_az_1b.workers_com_security_group_id},${module.aws_az_1c.workers_com_security_group_id},${module.aws_az_1e.workers_com_security_group_id}"
   site                                   = "com"
   syslog_address                         = "${var.syslog_address_com}"
   worker_ami                             = "${var.worker_ami}"
@@ -165,7 +183,7 @@ module "aws_asg_com" {
   worker_docker_image_ruby               = "${var.garnet_image}"
   worker_instance_type                   = "c3.8xlarge"
   worker_queue                           = "ec2"
-  worker_subnets                         = "${data.terraform_remote_state.vpc.workers_com_subnet_1b_id},${data.terraform_remote_state.vpc.workers_com_subnet_1e_id}"
+  worker_subnets                         = "${data.terraform_remote_state.vpc.workers_com_subnet_1a_id},${data.terraform_remote_state.vpc.workers_com_subnet_1b_id},${data.terraform_remote_state.vpc.workers_com_subnet_1c_id},${data.terraform_remote_state.vpc.workers_com_subnet_1e_id}"
 }
 
 module "aws_asg_org" {


### PR DESCRIPTION
Signed-off-by: Dan Buch <dan@travis-ci.org>

## What is the problem that this PR is trying to fix?

@solarce recently noticed that the `aws-production-2` infrastructure was only configured to use the us-east-1b and us-east-1e AZs, whereas `aws-precise-production-2` was using all four AZs.  We want to be using all four AZs in `aws-production-2` to insulate us from issues that happen at the AZ level.

## What approach did you choose and why?

I copied from the `aws-precise-production-2/main.tf` 😁  It works!

## How can you test this?

It is `make plan`-able, and should be `make apply`-able too.