### PR TITLE
Twiddle the post-flight slack hook a bit

### DIFF
--- a/bin/post-flight
+++ b/bin/post-flight
@@ -1,17 +1,41 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -o errexit
 
-[ -z "${SLACK_WEBHOOK}" ] && echo "Please export SLACK_WEBHOOK environment variable" && exit 1
+main() {
+  [ -n "${SLACK_WEBHOOK}" ] || {
+    echo "Missing SLACK_WEBHOOK variable"
+    exit 1
+  }
 
-workdir="$(pwd)"
-cmd="$(ps -o args= $PPID)"
-git_info=$(tr '\t' ' ' <"$1/.git/FETCH_HEAD")
-git_diff=$(git diff --name-only "${workdir}")
+  local workdir cmd git_info git_diff formatted_text
+  workdir="$(pwd)"
+  cmd="$(ps -o args= "${PPID}")"
+  git_info="$(git rev-parse --abbrev-ref HEAD)"
+  git_diff="$(git diff --name-only "${workdir}")"
+  formatted_text="$(
+    __format_text "${cmd}" "${workdir}" "${git_info}" "${git_diff}"
+  )"
+  payload='{
+    "channel": "#infra-terraform",
+    "username": "terraform-config",
+    "text": "'"${formatted_text}"'",
+    "icon_emoji":":computer:"
+  }'
 
-echo "Sending Slack notification... "
-# shellcheck disable=2016 disable=2086
-curl -X POST --data-urlencode \
-  'payload={"channel": "#infra-terraform", "username": "terraform-config", "text": "*terraform action /!\\*
-    user `'"${USER}"'` ran `'"${cmd}"'` in `'"$(basename ${workdir})"'`
-    on: `'"${git_info}"'`
-    any dirty files will be listed below: ``` '"${git_diff}"'```
-    ","icon_emoji":":computer:"}' "${SLACK_WEBHOOK}"
+  echo 'Sending Slack notification... '
+  curl -X POST --data-urlencode "payload=${payload}" "${SLACK_WEBHOOK}"
+}
+
+__format_text() {
+cat <<EOF
+*terraform action* :warning:
+  user \`${SLACK_USER:-$USER}\`
+    ran \`${1}\`
+    in \`$(basename "${2}")\`
+  on: \`${3}\`
+  any dirty files will be listed below: \`\`\` ${4}\`\`\`
+EOF
+}
+
+
+main "$@"

--- a/bin/post-flight
+++ b/bin/post-flight
@@ -27,7 +27,7 @@ main() {
 }
 
 __format_text() {
-cat <<EOF
+  cat <<EOF
 *terraform action* :warning:
   user \`${SLACK_USER:-$USER}\`
     ran \`${1}\`
@@ -36,6 +36,5 @@ cat <<EOF
   any dirty files will be listed below: \`\`\` ${4}\`\`\`
 EOF
 }
-
 
 main "$@"


### PR DESCRIPTION
to report the git branch only, and match (ish) style of other scripts
here.

## What is the problem that this PR is trying to fix?

When I run `bin/post-flight`, it results in the line with `on: ` having the contents of `.git/FETCH_HEAD`, which (for me) is ALOT of text.

## What approach did you choose and why?

I set the `on: ` line to have the git branch name instead.  I also twiddled around the script a bit to match other bash script style in this repo.

## How can you test this?

Run it!

## What feedback would you like, if any?

Is it OK that I've changed the style?  I admit that I can't cite a style document for how I've been writing bash stuff, but I _can_ provide some reasoning for the patterns I've adopted, which I'm happy to adapt whenever `shellcheck` and `shfmt` change their minds :grin: