### PR TITLE
Run 3x workers on GCE instances

### DIFF
--- a/assets/travis-worker/travis-worker-wrapper
+++ b/assets/travis-worker/travis-worker-wrapper
@@ -2,12 +2,14 @@
 set -o errexit
 
 main() {
-  docker stop travis-worker &>/dev/null || true
-  docker rm -f travis-worker &>/dev/null || true
+  local name="${1:-travis-worker}"
+
+  docker stop "${name}" &>/dev/null || true
+  docker rm -f "${name}" &>/dev/null || true
 
   local run_dir=/var/tmp/travis-run.d
   mkdir -p "${run_dir}"
-  local env_file="${run_dir}/env"
+  local env_file="${run_dir}/${name}.env"
   travis-tfw-combined-env travis-worker >"${env_file}"
   set -o allexport
   # shellcheck source=/dev/null
@@ -19,7 +21,7 @@ main() {
 
   exec docker run \
     --rm \
-    --name travis-worker \
+    --name "${name}" \
     --hostname "$(hostname)" \
     --userns host \
     -v /var/tmp:/var/tmp \

--- a/assets/travis-worker/travis-worker.conf
+++ b/assets/travis-worker/travis-worker.conf
@@ -15,4 +15,4 @@ console log
 
 post-stop exec sleep 5
 
-exec travis-worker-wrapper
+exec travis-worker-wrapper $UPSTART_JOB

--- a/modules/gce_worker/cloud-config.yml.tpl
+++ b/modules/gce_worker/cloud-config.yml.tpl
@@ -8,15 +8,7 @@ write_files:
 - content: '${base64encode(worker_config)}'
   encoding: b64
   owner: 'travis:travis'
-  path: /etc/default/travis-worker-a
-- content: '${base64encode(worker_config)}'
-  encoding: b64
-  owner: 'travis:travis'
-  path: /etc/default/travis-worker-b
-- content: '${base64encode(worker_config)}'
-  encoding: b64
-  owner: 'travis:travis'
-  path: /etc/default/travis-worker-c
+  path: /etc/default/travis-worker
 - content: '${base64encode(cloud_init_env)}'
   encoding: b64
   owner: 'travis:travis'

--- a/modules/gce_worker/cloud-config.yml.tpl
+++ b/modules/gce_worker/cloud-config.yml.tpl
@@ -8,7 +8,15 @@ write_files:
 - content: '${base64encode(worker_config)}'
   encoding: b64
   owner: 'travis:travis'
-  path: /etc/default/travis-worker
+  path: /etc/default/travis-worker-a
+- content: '${base64encode(worker_config)}'
+  encoding: b64
+  owner: 'travis:travis'
+  path: /etc/default/travis-worker-b
+- content: '${base64encode(worker_config)}'
+  encoding: b64
+  owner: 'travis:travis'
+  path: /etc/default/travis-worker-c
 - content: '${base64encode(cloud_init_env)}'
   encoding: b64
   owner: 'travis:travis'

--- a/modules/gce_worker/cloud-init.bash
+++ b/modules/gce_worker/cloud-init.bash
@@ -8,22 +8,31 @@ main() {
   : "${ETCDIR:=/etc}"
   : "${VARTMP:=/var/tmp}"
   : "${RUNDIR:=/var/tmp/travis-run.d}"
+  : "${WORKER_SUFFIXES:=a b c}"
 
   chown -R travis:travis "${RUNDIR}"
 
   if [[ -d "${ETCDIR}/systemd/system" ]]; then
-    cp -v "${VARTMP}/travis-worker.service" \
-      "${ETCDIR}/systemd/system/travis-worker.service"
-    systemctl enable travis-worker || true
+    for worker_suffix in ${WORKER_SUFFIXES}; do
+      cp -v "${VARTMP}/travis-worker.service" \
+        "${ETCDIR}/systemd/system/travis-worker-${worker_suffix}.service"
+      systemctl enable "travis-worker-${worker_suffix}" || true
+    done
   fi
 
   if [[ -d "${ETCDIR}/init" ]]; then
     cp -v "${VARTMP}/travis-worker.conf" \
       "${ETCDIR}/init/travis-worker.conf"
+    for worker_suffix in ${WORKER_SUFFIXES}; do
+      cp -v "${VARTMP}/travis-worker.conf" \
+        "${ETCDIR}/init/travis-worker-${worker_suffix}.conf"
+    done
   fi
 
-  service travis-worker stop || true
-  service travis-worker start || true
+  for worker_suffix in ${WORKER_SUFFIXES}; do
+    service "travis-worker-${worker_suffix}" stop || true
+    service "travis-worker-${worker_suffix}" start || true
+  done
 
   __wait_for_docker
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

We currently run 1x `travis-worker` process per GCE instance, each being a `g1.small` machine type.  These machines are barely utilized, and the recent shift to run a smaller pool size per worker to reduce the impact of worker restarts means that we're utilizing them even less.

## What approach did you choose and why?

Create 3x `travis-worker` upstart (or systemd) configs, making 3x the worker processes per instance.

## How can you test this?

GCE staging fun times.

## What feedback would you like, if any?

Should the multiplier be configurable, or is 3x per instance a reasonable start?  Other?