### PR TITLE
More twiddling with post-flight formatting

### DIFF
--- a/bin/post-flight
+++ b/bin/post-flight
@@ -7,14 +7,8 @@ main() {
     exit 1
   }
 
-  local workdir cmd git_info git_diff formatted_text
-  workdir="$(pwd)"
-  cmd="$(ps -o args= "${PPID}")"
-  git_info="$(git rev-parse --abbrev-ref HEAD)"
-  git_diff="$(git diff --name-only "${workdir}")"
-  formatted_text="$(
-    __format_text "${cmd}" "${workdir}" "${git_info}" "${git_diff}"
-  )"
+  local formatted_text
+  formatted_text="$(__format_text "$(ps -o args= "${PPID}")" "$(pwd)")"
   payload='{
     "channel": "#infra-terraform",
     "username": "terraform-config",
@@ -27,14 +21,37 @@ main() {
 }
 
 __format_text() {
+  local cmd="${1}"
+  local dir="${2}"
+  local user="${SLACK_USER:-$USER}"
+
   cat <<EOF
 *terraform action* :warning:
-  user \`${SLACK_USER:-$USER}\`
-    ran \`${1}\`
-    in \`$(basename "${2}")\`
-  on: \`${3}\`
-  any dirty files will be listed below: \`\`\` ${4}\`\`\`
+  ${user} ran \`${cmd}\` in \`$(basename "${dir}")\`
+  on branch: \`$(__git_branch)\`$(__format_dirty_files)
 EOF
+}
+
+__format_dirty_files() {
+  local diff_names
+  diff_names="$(__git_diff_names | LC_ALL=C sort | uniq)"
+  if [[ "${diff_names}" ]]; then
+    cat <<EOF
+
+  dirty files: \`\`\`${diff_names}\`\`\`
+EOF
+  fi
+}
+
+__git_branch() {
+  git rev-parse --abbrev-ref HEAD
+}
+
+__git_diff_names() {
+  pushd "$(git rev-parse --show-toplevel)" &>/dev/null
+  git diff --name-only
+  git diff --cached --name-only
+  popd &>/dev/null
 }
 
 main "$@"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Empty triple backticks when working copy is clean.

## What approach did you choose and why?

Only show diff and staged file names if changes present.

## How can you test this?

Run `./bin/post-flight` and look at Slack
