### PR TITLE
Clean up some renamed files in GCE projects

### DIFF
--- a/gce-production-2/main.tf
+++ b/gce-production-2/main.tf
@@ -71,8 +71,8 @@ module "gce_project_1" {
   worker_config_com = <<EOF
 ### worker.env
 ${file("${path.module}/worker.env")}
-### config/worker-env-com
-${file("${path.module}/config/worker-env-com")}
+### config/worker-com.env
+${file("${path.module}/config/worker-com.env")}
 
 export TRAVIS_WORKER_GCE_SUBNETWORK=workerscom
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
@@ -83,8 +83,8 @@ EOF
   worker_config_org = <<EOF
 ### worker.env
 ${file("${path.module}/worker.env")}
-### config/worker-env-org
-${file("${path.module}/config/worker-env-org")}
+### config/worker-org.env
+${file("${path.module}/config/worker-org.env")}
 
 export TRAVIS_WORKER_GCE_PUBLIC_IP=true
 export TRAVIS_WORKER_GCE_PUBLIC_IP_CONNECT=false

--- a/gce-production-3/main.tf
+++ b/gce-production-3/main.tf
@@ -71,8 +71,8 @@ module "gce_project_1" {
   worker_config_com = <<EOF
 ### worker.env
 ${file("${path.module}/worker.env")}
-### config/worker-env-com
-${file("${path.module}/config/worker-env-com")}
+### config/worker-com.env
+${file("${path.module}/config/worker-com.env")}
 
 export TRAVIS_WORKER_GCE_SUBNETWORK=workerscom
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
@@ -83,8 +83,8 @@ EOF
   worker_config_org = <<EOF
 ### worker.env
 ${file("${path.module}/worker.env")}
-### config/worker-env-org
-${file("${path.module}/config/worker-env-org")}
+### config/worker-org.env
+${file("${path.module}/config/worker-org.env")}
 
 export TRAVIS_WORKER_GCE_PUBLIC_IP=true
 export TRAVIS_WORKER_GCE_PUBLIC_IP_CONNECT=false

--- a/gce-production-4/main.tf
+++ b/gce-production-4/main.tf
@@ -71,8 +71,8 @@ module "gce_project_1" {
   worker_config_com = <<EOF
 ### worker.env
 ${file("${path.module}/worker.env")}
-### config/worker-env-com
-${file("${path.module}/config/worker-env-com")}
+### config/worker-com.env
+${file("${path.module}/config/worker-com.env")}
 
 export TRAVIS_WORKER_GCE_SUBNETWORK=workerscom
 export TRAVIS_WORKER_HARD_TIMEOUT=120m
@@ -83,8 +83,8 @@ EOF
   worker_config_org = <<EOF
 ### worker.env
 ${file("${path.module}/worker.env")}
-### config/worker-env-org
-${file("${path.module}/config/worker-env-org")}
+### config/worker-org.env
+${file("${path.module}/config/worker-org.env")}
 
 export TRAVIS_WORKER_GCE_PUBLIC_IP=true
 export TRAVIS_WORKER_GCE_PUBLIC_IP_CONNECT=false

--- a/gce-production-5/main.tf
+++ b/gce-production-5/main.tf
@@ -71,8 +71,8 @@ module "gce_project_1" {
   worker_config_com = <<EOF
 ### worker.env
 ${file("${path.module}/worker.env")}
-### config/worker-env-com
-${file("${path.module}/config/worker-env-com")}
+### config/worker-com.env
+${file("${path.module}/config/worker-com.env")}
 
 export TRAVIS_WORKER_GCE_SUBNETWORK=workerscom
 export TRAVIS_WORKER_HARD_TIMEOUT=120m


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

`make plan` is busted for these GCE projects.  I'm not sure what combination of branch and state I was using to get these to work when I committed them last, so I'm guessing it means I did it wrong :sweat_smile:

## What approach did you choose and why?

Unbreakage

## How can you test this?

`make plan` works now