### PR TITLE
Drop the org worker count

### DIFF
--- a/gce-production-1/main.tf
+++ b/gce-production-1/main.tf
@@ -61,7 +61,7 @@ module "gce_project_1" {
   worker_account_json_org       = "${file("${path.module}/config/gce-workers-production-1.json")}"
   worker_image                  = "${var.gce_worker_image}"
   worker_instance_count_com     = 12
-  worker_instance_count_org     = 50
+  worker_instance_count_org     = 18
 
   public_subnet_cidr_range    = "10.10.1.0/24"
   workers_subnet_cidr_range   = "10.10.16.0/22"


### PR DESCRIPTION
to compensate for the 3x workers change.

## What is the problem that this PR is trying to fix?

The new GCE worker instance config creates 3x `travis-worker` per instance.  This change drops the instance count such that the capacity changes from 750 to 810.

## What approach did you choose and why?

Reduce the worker instance count because the total capacity per instance is up from 15 to 45.

## How can you test this?

`make plan` ➕ `make apply`