### PR TITLE
Add commit hash to Slack notification

### DIFF
--- a/bin/post-flight
+++ b/bin/post-flight
@@ -44,7 +44,7 @@ EOF
 }
 
 __git_branch_at_commit() {
-  printf "%s @ %s" "$(git rev-parse --abbrev-ref HEAD)" "$(git log --oneline -1)"
+  printf "%s @ %s" "$(git rev-parse --abbrev-ref HEAD)" "$(git log --format='%h' -1)"
 }
 
 __git_diff_names() {

--- a/bin/post-flight
+++ b/bin/post-flight
@@ -28,7 +28,7 @@ __format_text() {
   cat <<EOF
 *terraform action* :warning:
   ${user} ran \`${cmd}\` in \`$(basename "${dir}")\`
-  on branch: \`$(__git_branch)\`$(__format_dirty_files)
+  on branch @ commit: \`$(__git_branch_at_commit)\`$(__format_dirty_files)
 EOF
 }
 
@@ -43,8 +43,8 @@ EOF
   fi
 }
 
-__git_branch() {
-  git rev-parse --abbrev-ref HEAD
+__git_branch_at_commit() {
+  printf "%s @ %s" "$(git rev-parse --abbrev-ref HEAD)" "$(git log --oneline -1)"
 }
 
 __git_diff_names() {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The Slack notification when one runs `make apply` should include the git commit.

## What approach did you choose and why?

Add the commit to the output, e.g. `branch @ commit`.

## How can you test this?

Run it!
