### PR TITLE
Roll back macstadium to worker v2.11.0

### DIFF
--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -5,7 +5,7 @@ variable "index" {
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v3.0.2"
+  default = "v2.11.0"
 }
 
 variable "travisci_net_external_zone_id" {

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -5,7 +5,7 @@ variable "index" {
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v3.0.2"
+  default = "v2.11.0"
 }
 
 variable "travisci_net_external_zone_id" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Backlog is big and not getting less big at the usual rate.

## What approach did you choose and why?

Roll it back to when it made the backlog less big more quickly.

## How can you test this?

N/A :tada: