### PR TITLE
Terraform module for CloudWatch ASG dashboards

### DIFF
--- a/modules/aws_asg/dashboards.tf
+++ b/modules/aws_asg/dashboards.tf
@@ -1,0 +1,77 @@
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "${var.env}-${var.site}"
+
+  dashboard_body = <<EOF
+{
+    "widgets": [
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 0,
+            "width": 24,
+            "height": 6,
+            "properties": {
+                "view": "timeSeries",
+                "stacked": true,
+                "metrics": [
+                    [ "Travis/${var.site}${var.env == "staging" ? "-staging" : ""}", "v1.travis.rabbitmq.consumers.${var.env}.builds.ec2.headroom", { "color": "#2ca02c", "period": 60, "stat": "Average" } ]
+                ],
+                "region": "us-east-1",
+                "annotations": {
+                    "horizontal": [
+                        {
+                            "color": "#ff7f0e",
+                            "label": "Add ${var.worker_asg_scale_out_qty * 2} instances",
+                            "value": ${var.worker_asg_scale_out_threshold + floor(var.worker_asg_scale_out_threshold/-2.0)}
+                        },
+                        {
+                            "color": "#bcbd22",
+                            "label": "Add ${var.worker_asg_scale_out_qty} instances",
+                            "value": ${var.worker_asg_scale_out_threshold}
+                        },
+                        {
+                            "label": "Remove ${var.worker_asg_scale_in_qty} instance",
+                            "value": "${var.worker_asg_scale_in_threshold}"
+                        },
+                        {
+                            "label": "Remove ${var.worker_asg_scale_in_qty * 2} instances",
+                            "value": "${var.worker_asg_scale_in_threshold + ceil(var.worker_asg_scale_in_threshold / 2)}"
+                        },
+                        {
+                            "color": "#d62728",
+                            "label": "Add ${var.worker_asg_scale_out_qty * 3} instances",
+                            "value": "${var.worker_asg_scale_out_threshold + floor(var.worker_asg_scale_out_threshold/-1.0)}"
+                        }
+                    ]
+                },
+                "title": "Headroom [${var.site}-${var.env}] (terraform)",
+                "period": 300
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 6,
+            "width": 24,
+            "height": 9,
+            "properties": {
+                "view": "timeSeries",
+                "stacked": true,
+                "metrics": [
+                    [ "AWS/AutoScaling", "GroupInServiceInstances", "AutoScalingGroupName", "${var.env}-${var.index}-workers-${var.site}", { "color": "#2ca02c", "period": 30, "stat": "Average" } ],
+                    [ ".", "GroupPendingInstances", ".", ".", { "color": "#bcbd22", "period": 30 } ],
+                    [ ".", "GroupTerminatingInstances", ".", ".", { "color": "#d62728", "period": 30 } ]
+                ],
+                "region": "us-east-1",
+                "period": 300,
+                "yAxis": {
+                    "left": {
+                        "min": ${var.worker_asg_min_size}
+                    }
+                }
+            }
+        }
+    ]
+}
+ EOF
+}


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Lack of visual representation of autoscaling events.

## What approach did you choose and why?

I had manually made a dashboard which was great for tracking autoscaling events, but annoying because the thresholds (the horizontal annotations corresponding to each scaling step) didn't stay up to date. So I made it a terraform module instead.

## How can you test this?

Check out the [staging-org dashboard](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=staging-org) (generated by Terraform) or the [production-org](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=production-org) (created manually, to be replaced with Terraform version which should be identical).

## What feedback would you like, if any?

