### PR TITLE
Check docker health with a cron job

### DIFF
--- a/bin/travis-worker-verify-config
+++ b/bin/travis-worker-verify-config
@@ -81,7 +81,7 @@ class TravisWorkerConfigVerifier
 
   def verify_etc_cron_d_check_docker_health!(content)
     assert_identical_content!(
-      content, 'modules/aws_asg/check-docker-health.crontab'
+      content, 'modules/aws_asg/check-docker-health-crontab'
     )
   end
 

--- a/bin/travis-worker-verify-config
+++ b/bin/travis-worker-verify-config
@@ -1,4 +1,7 @@
 #!/usr/bin/env ruby
+# This executable is run via null resource provisioner
+# but you can run it directly, too
+
 require 'base64'
 require 'json'
 require 'pathname'

--- a/bin/travis-worker-verify-config
+++ b/bin/travis-worker-verify-config
@@ -73,6 +73,18 @@ class TravisWorkerConfigVerifier
     )
   end
 
+  def verify_var_tmp_travis_run_d_check_docker_health!(content)
+    assert_identical_content!(
+      content, 'modules/aws_asg/check-docker-health.bash'
+    )
+  end
+
+  def verify_etc_cron_d_check_docker_health!(content)
+    assert_identical_content!(
+      content, 'modules/aws_asg/check-docker-health.crontab'
+    )
+  end
+
   def verify_etc_default_github_users!(content)
     vars = load_env_file(content)
     assert!(vars.key?('GITHUB_USERS'), msg: 'does not define GITHUB_USERS')

--- a/modules/aws_asg/bats_helpers.bash
+++ b/modules/aws_asg/bats_helpers.bash
@@ -5,6 +5,7 @@ aws_asg_setup() {
   export ETCDIR="${BATS_TMPDIR}/etc"
   export VARTMP="${BATS_TMPDIR}/var/tmp"
   export MOCKLOG="${BATS_TMPDIR}/logs/mock.log"
+  export KILL_COMMAND="${BATS_TMPDIR}/bin/kill_mocked"
 
   mkdir -p \
     "${RUNDIR}" \
@@ -46,16 +47,22 @@ EOF
   chmod +x "${BATS_TMPDIR}/bin/mock"
 
   for cmd in \
+    awk \
     chown \
     dmesg \
+    date \
     docker \
     iptables \
+    kill_mocked \
+    logger \
+    pidof \
     sed \
     service \
     shutdown \
     sleep \
     sysctl \
-    systemctl; do
+    systemctl \
+    timeout; do
     pushd "${BATS_TMPDIR}/bin" &>/dev/null
     ln -svf mock "${cmd}"
     popd &>/dev/null

--- a/modules/aws_asg/check-docker-health-crontab
+++ b/modules/aws_asg/check-docker-health-crontab
@@ -1,0 +1,3 @@
+SHELL = /bin/bash
+
+* * * * * root /var/tmp/travis-run.d/check-docker-health >> /var/log/syslog

--- a/modules/aws_asg/check-docker-health.bash
+++ b/modules/aws_asg/check-docker-health.bash
@@ -59,7 +59,7 @@ __handle_unresponsive_docker() {
   sleep "${post_sleep}"
 
   if [ -e "${run_d}/implode" ]; then
-    "${KILL_COMMAND}" -INT "$(pidof travis-worker)" || restart travis-worker
+    "${KILL_COMMAND}" -TERM "$(pidof travis-worker)" || restart travis-worker
   else
     logger "${run_d}/implode not found, not imploding?"
     __die noop 0

--- a/modules/aws_asg/check-docker-health.bash
+++ b/modules/aws_asg/check-docker-health.bash
@@ -34,6 +34,12 @@ main() {
     __handle_unresponsive_docker "${run_d}"
     __die imploding 86
   fi
+
+  if [ -e "${run_d}/implode" ]; then
+    logger "docker no longer seems unhealthy; canceling implosion."
+    rm "${run_d}/implode"
+  fi
+
   __die noop 0
 }
 

--- a/modules/aws_asg/check-docker-health.bash
+++ b/modules/aws_asg/check-docker-health.bash
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o pipefail
+
+# Sometimes, the docker service will be running, but certain commands (docker ps) will hang indefinitely.
+# This script detects this behavior and implodes the instance when it occurs.
+
+main() {
+  local warmup_grace_period=600
+  local post_sleep="${POST_SHUTDOWN_SLEEP}"
+  local sleep_time="${DOCKER_PS_SLEEP_TIME}"
+  local run_d="${RUNDIR}"
+  : "${post_sleep:=300}"
+  : "${sleep_time:=5}"
+  : "${run_d:=/var/tmp/travis-run.d}"
+  : "${KILL_COMMAND:=kill}"
+
+  if [[ -f "${run_d}/implode.confirm" ]]; then
+    __handle_implode_confirm "${run_d}" "${post_sleep}"
+    __die imploded 42
+  fi
+
+  # Don't run this unless instance has been up at least $warmup_grace_period seconds
+  uptime_as_int=$(printf "%.0f\n" "$(awk '{ print $1}' /proc/uptime)")
+  if [[ "${uptime_as_int}" -lt "${warmup_grace_period}" ]]; then
+    logger "Not checking docker health yet, as uptime is still less than ${warmup_grace_period} seconds"
+    __die noop 0
+  fi
+
+  logger "Checking docker health..."
+  result=$(timeout "${sleep_time}"s docker ps) || true
+
+  if [ -z "${result}" ]; then
+    __handle_unresponsive_docker "${run_d}"
+    __die imploding 86
+  fi
+  __die noop 0
+}
+
+__handle_implode_confirm() {
+  local run_d="${1}"
+  local post_sleep="${2}"
+
+  local reason
+  reason="$(cat "${run_d}/implode.confirm" 2>/dev/null)"
+  : "${reason:=not sure why}"
+  "${SHUTDOWN:-/sbin/shutdown}" -P now "imploding because ${reason}"
+  sleep "${post_sleep}"
+}
+
+__handle_unresponsive_docker() {
+  local run_d="${1}"
+  msg="docker appears to be unhealthy"
+  echo "$msg" |
+    tee "${run_d}/implode"
+  logger "$msg"
+
+  logger "Sleeping ${post_sleep}"
+  sleep "${post_sleep}"
+
+  if [ -e "${run_d}/implode" ]; then
+    "${KILL_COMMAND}" -INT "$(pidof travis-worker)" || restart travis-worker
+  else
+    logger "${run_d}/implode not found, not imploding?"
+    __die noop 0
+  fi
+
+}
+
+__die() {
+  local status="${1}"
+  local code="${2}"
+  logger "time=$(date -u +%Y%m%dT%H%M%S) " \
+    "prog=$(basename "${0}") status=${status}"
+  exit "${code}"
+}
+
+main "$@"

--- a/modules/aws_asg/check-docker-health.bats
+++ b/modules/aws_asg/check-docker-health.bats
@@ -23,7 +23,6 @@ run_check_docker_health() {
 EOF
   echo 'docker appears to be unhealthy' >"${RUNDIR}/implode.confirm"
   run run_check_docker_health
-  KILL_COMMAND="${BATS_TMPDIR}/bin/kill_mocked"
 
   assert_cmd 'shutdown -P now.+imploding because docker appears to be unhealthy'
   assert_cmd 'sleep 0.1'
@@ -104,7 +103,6 @@ EOF
 EOF
 
   run run_check_docker_health
-  cat /tmp/logs/mock.log
   assert_cmd "kill_mocked -INT 42"
 
   [ -f "${RUNDIR}/implode" ]

--- a/modules/aws_asg/check-docker-health.bats
+++ b/modules/aws_asg/check-docker-health.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+
+load bats_helpers
+
+setup() {
+  export DOCKER_PS_SLEEP_TIME=2
+  export POST_SHUTDOWN_SLEEP=0.1
+  export SHUTDOWN=shutdown
+  aws_asg_setup
+}
+
+teardown() {
+  aws_asg_teardown
+}
+
+run_check_docker_health() {
+  bash "${BATS_TEST_DIRNAME}/check-docker-health.bash"
+}
+
+@test "handles implosion confirmation" {
+  cat >"${BATS_TMPDIR}/returns/date" <<EOF
+20171030T153252
+EOF
+  echo 'docker appears to be unhealthy' >"${RUNDIR}/implode.confirm"
+  run run_check_docker_health
+  KILL_COMMAND="${BATS_TMPDIR}/bin/kill_mocked"
+
+  assert_cmd 'shutdown -P now.+imploding because docker appears to be unhealthy'
+  assert_cmd 'sleep 0.1'
+  [ "${status}" -eq 42 ]
+  assert_cmd "logger time=20171030T153252  prog=check-docker-health.bash status=imploded"
+}
+
+@test "handles implosion confirmation when docker is unhealthy" {
+  cat >"${BATS_TMPDIR}/returns/date" <<EOF
+20171030T153252
+EOF
+
+  touch "${RUNDIR}/implode.confirm"
+
+  run run_check_docker_health
+  [ "${status}" -eq 42 ]
+  assert_cmd "logger time=20171030T153252  prog=check-docker-health.bash status=imploded"
+}
+
+@test "is a no-op if uptime is too low" {
+  # an empty result means 'docker ps' has not responded...
+  cat >"${BATS_TMPDIR}/returns/timeout" <<EOF
+EOF
+
+  # ...but an empty result should not trigger an imposion if the instance is new
+  cat >"${BATS_TMPDIR}/returns/awk" <<EOF
+60
+EOF
+
+  cat >"${BATS_TMPDIR}/returns/date" <<EOF
+20171030T153252
+EOF
+
+  run run_check_docker_health
+  [ "${status}" -eq 0 ]
+  assert_cmd "logger time=20171030T153252  prog=check-docker-health.bash status=noop"
+}
+
+@test "is a no-op if docker ps is ok" {
+  # 'docker ps' returns a result and should be considered healthy
+  cat >"${BATS_TMPDIR}/returns/timeout" <<EOF
+CONTAINER ID IMAGE COMMAND CREATED STATUS PORTS NAMES
+EOF
+
+  cat >"${RUNDIR}/implode" <<EOF
+EOF
+
+  cat >"${BATS_TMPDIR}/returns/date" <<EOF
+20171030T153252
+EOF
+
+  run run_check_docker_health
+
+  [ "${status}" -eq 0 ]
+  assert_cmd "logger time=20171030T153252  prog=check-docker-health.bash status=noop"
+}
+
+@test "triggers an implosion when docker is unhealthy" {
+  # an empty result means 'docker ps' has not responded...
+  cat >"${BATS_TMPDIR}/returns/timeout" <<EOF
+EOF
+
+  # ...and the instance has been running long enough for us to expect docker to respond
+  cat >"${BATS_TMPDIR}/returns/awk" <<EOF
+60000
+EOF
+
+  cat >"${BATS_TMPDIR}/returns/pidof" <<EOF
+42
+EOF
+
+  cat >"${RUNDIR}/implode" <<EOF
+docker appears to be unhealthy
+EOF
+
+  cat >"${BATS_TMPDIR}/returns/date" <<EOF
+20171030T153252
+EOF
+
+  run run_check_docker_health
+  cat /tmp/logs/mock.log
+  assert_cmd "kill_mocked -INT 42"
+
+  [ -f "${RUNDIR}/implode" ]
+  [ "${status}" -eq 86 ]
+  assert_cmd "logger time=20171030T153252  prog=check-docker-health.bash status=imploding"
+}

--- a/modules/aws_asg/check-docker-health.bats
+++ b/modules/aws_asg/check-docker-health.bats
@@ -103,7 +103,7 @@ EOF
 EOF
 
   run run_check_docker_health
-  assert_cmd "kill_mocked -INT 42"
+  assert_cmd "kill_mocked -TERM 42"
 
   [ -f "${RUNDIR}/implode" ]
   [ "${status}" -eq 86 ]

--- a/modules/aws_asg/cloud-config.yml.tpl
+++ b/modules/aws_asg/cloud-config.yml.tpl
@@ -66,6 +66,16 @@ write_files:
   encoding: b64
   owner: 'root:root'
   path: /var/tmp/travis-worker.conf
+- content: '${base64encode(file("${here}/check-docker-health.bash"))}'
+  encoding: b64
+  owner: 'root:root'
+  path: /var/tmp/travis-run.d/check-docker-health
+  permissions: '0750'
+- content: '${base64encode(file("${here}/check-docker-health-crontab"))}'
+  encoding: b64
+  owner: 'root:root'
+  path: /etc/cron.d/check-docker-health-crontab
+  permissions: '0644'
 - content: '${base64encode(file("${assets}/travis-worker/travis-worker.service"))}'
   encoding: b64
   owner: 'root:root'

--- a/runtests
+++ b/runtests
@@ -5,8 +5,10 @@ set -o pipefail
 
 main() {
   # abort if there are uncommitted local changes
-  msg="You have uncommitted changes. Not proceeding, as this script changes some files in place."
-  git diff-index --quiet HEAD -- || (echo "$msg" && exit 1)
+  if [[ "$1" != "--force" ]]; then
+    msg="You have uncommitted changes. Not proceeding, as this script changes some files in place. (Use --force to override)"
+    git diff-index --quiet HEAD -- || (echo "$msg" && exit 1)
+  fi
 
   if [[ $# -gt 1 && $1 == --env ]]; then
     echo "Running isolated with env ${2}"

--- a/runtests
+++ b/runtests
@@ -5,7 +5,7 @@ set -o pipefail
 
 main() {
   # abort if there are uncommitted local changes
-  if [[ "$1" != "--force" ]]; then
+  if [[ "${*}" =~ --force ]]; then
     msg="You have uncommitted changes. Not proceeding, as this script changes some files in place. (Use --force to override)"
     git diff-index --quiet HEAD -- || (echo "$msg" && exit 1)
   fi


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

`docker` sometimes gets into a weird state on worker instances.

## What approach did you choose and why?

This PR adds an hourly cron job to check that docker is still responsive. If not, the instance is imploded.

## How can you test this?

We'll see on staging?

## What feedback would you like, if any?

* Is there a better way?
* Should be consider rebooting instead of shutting down?

Addresses https://github.com/travis-pro/team-blue/issues/704