### PR TITLE
Bump worker to v3.1.0

### DIFF
--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -5,7 +5,7 @@ variable "index" {
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v2.11.0"
+  default = "v3.1.0"
 }
 
 variable "travisci_net_external_zone_id" {

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -5,7 +5,7 @@ variable "index" {
 variable "latest_travis_worker_version" {}
 
 variable "travis_worker_version" {
-  default = "v2.11.0"
+  default = "v3.1.0"
 }
 
 variable "travisci_net_external_zone_id" {

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -115,7 +115,7 @@ variable "worker_docker_image_python" {}
 variable "worker_docker_image_ruby" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v2.11.0"
+  default = "travisci/worker:v3.1.0"
 }
 
 variable "worker_instance_type" {

--- a/modules/gce_project/main.tf
+++ b/modules/gce_project/main.tf
@@ -71,8 +71,9 @@ variable "zone_count" {
 }
 
 resource "google_compute_network" "main" {
-  name    = "main"
-  project = "${var.project}"
+  name                    = "main"
+  project                 = "${var.project}"
+  auto_create_subnetworks = "false"
 }
 
 output "gce_network" {

--- a/modules/gce_project/main.tf
+++ b/modules/gce_project/main.tf
@@ -35,7 +35,7 @@ variable "worker_config_com" {}
 variable "worker_config_org" {}
 
 variable "worker_docker_self_image" {
-  default = "travisci/worker:v2.11.0"
+  default = "travisci/worker:v3.1.0"
 }
 
 variable "worker_image" {}

--- a/modules/gce_worker/cloud-init.bash
+++ b/modules/gce_worker/cloud-init.bash
@@ -21,8 +21,6 @@ main() {
   fi
 
   if [[ -d "${ETCDIR}/init" ]]; then
-    cp -v "${VARTMP}/travis-worker.conf" \
-      "${ETCDIR}/init/travis-worker.conf"
     for worker_suffix in ${WORKER_SUFFIXES}; do
       cp -v "${VARTMP}/travis-worker.conf" \
         "${ETCDIR}/init/travis-worker-${worker_suffix}.conf"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Production deployments of worker are currently at (rolled back to) v2.11.0.  There are some tasty bug fixes between v2.11.0 and v3.1.0.  The lack of v3.1.0 is sad!

## What approach did you choose and why?

Bump to v3.1.0

## How can you test this?

`make plan && make apply` in:

- [x] aws-staging-1
- [x] aws-production-2
- [x] <del>macstadium-shared-1</del>
- [x] <del>macstadium-shared-2</del>
- [x] gce-staging-1
- [x] gce-production-1
- [x] gce-production-2
- [x] gce-production-3
- [x] gce-production-4
- [x] gce-production-5
- [x] gce-production-6
