### PR TITLE
Use quay.io as registry for the build-env images

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -23,11 +23,11 @@ variable "worker_ami" {
 }
 
 variable "amethyst_image" {
-  default = "travisci/ci-amethyst:packer-1503974220"
+  default = "quay.io/travisci/ci-amethyst:packer-1503974220"
 }
 
 variable "garnet_image" {
-  default = "travisci/ci-garnet:packer-1503972846"
+  default = "quay.io/travisci/ci-garnet:packer-1503972846"
 }
 
 terraform {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Image pulls from Docker Hub stall, which prevents us from adding new hosts on AWS

## What approach did you choose and why?

## How can you test this?
`make clean plan` output:

```

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place
-/+ destroy and then create replacement

Terraform will perform the following actions:

-/+ null_resource.language_mapping_json (new resource required)
      id:                          "7464955170567500558" => <computed> (forces new resource)
      triggers.%:                  "2" => "2"
      triggers.amethyst_image:     "travisci/ci-amethyst:packer-1503974220" => "quay.io/travisci/ci-amethyst:packer-1503974220" (forces new resource)
      triggers.garnet_image:       "travisci/ci-garnet:packer-1503972846" => "quay.io/travisci/ci-garnet:packer-1503972846" (forces new resource)

  ~ module.aws_asg_com.aws_autoscaling_group.workers
      launch_configuration:        "production-2-workers-com-00754038303965d3f00d5b70fc" => "${aws_launch_configuration.workers.name}"

  ~ module.aws_asg_com.aws_autoscaling_policy.workers_remove_capacity
      estimated_instance_warmup:   "0" => "300"

-/+ module.aws_asg_com.aws_launch_configuration.workers (new resource required)
      id:                          "production-2-workers-com-00754038303965d3f00d5b70fc" => <computed> (forces new resource)
      associate_public_ip_address: "false" => "false"
      ebs_block_device.#:          "0" => <computed>
      ebs_optimized:               "false" => <computed>
      enable_monitoring:           "true" => "true"
      image_id:                    "ami-3e405045" => "ami-3e405045"
      instance_type:               "c3.8xlarge" => "c3.8xlarge"
      key_name:                    "" => <computed>
      name:                        "production-2-workers-com-00754038303965d3f00d5b70fc" => <computed>
      name_prefix:                 "production-2-workers-com-" => "production-2-workers-com-"
      root_block_device.#:         "0" => <computed>
      security_groups.#:           "4" => "4"
      security_groups.1206244775:  "sg-baf648c9" => "sg-baf648c9"
      security_groups.1507295911:  "sg-9f2860e5" => "sg-9f2860e5"
      security_groups.17498028:    "sg-bbf648c8" => "sg-bbf648c8"
      security_groups.4161445841:  "sg-962860ec" => "sg-962860ec"
      user_data:                   "409c3df805c0e4f303239e19500c50d698b85237" => "50708219be392718113c01bcdf9e6ec9bd3a43ab" (forces new resource)

  ~ module.aws_asg_cs50.aws_autoscaling_group.workers
      launch_configuration:        "cs50-production-2-workers-com-00754038303965d3f00d5b70fa" => "${aws_launch_configuration.workers.name}"

-/+ module.aws_asg_cs50.aws_launch_configuration.workers (new resource required)
      id:                          "cs50-production-2-workers-com-00754038303965d3f00d5b70fa" => <computed> (forces new resource)
      associate_public_ip_address: "false" => "false"
      ebs_block_device.#:          "0" => <computed>
      ebs_optimized:               "false" => <computed>
      enable_monitoring:           "true" => "true"
      image_id:                    "ami-3e405045" => "ami-3e405045"
      instance_type:               "c3.2xlarge" => "c3.2xlarge"
      key_name:                    "" => <computed>
      name:                        "cs50-production-2-workers-com-00754038303965d3f00d5b70fa" => <computed>
      name_prefix:                 "cs50-production-2-workers-com-" => "cs50-production-2-workers-com-"
      root_block_device.#:         "0" => <computed>
      security_groups.#:           "2" => "2"
      security_groups.1507295911:  "sg-9f2860e5" => "sg-9f2860e5"
      security_groups.4161445841:  "sg-962860ec" => "sg-962860ec"
      user_data:                   "9170a0dc503d57c5edffacbe2cea1516e4119315" => "ea95f8e6da3f602094aa9fb1ddc7c3f8bb4a5b7a" (forces new resource)

  ~ module.aws_asg_org.aws_autoscaling_group.workers
      launch_configuration:        "production-2-workers-org-00754038303965d3f00d5b70fb" => "${aws_launch_configuration.workers.name}"

  ~ module.aws_asg_org.aws_autoscaling_policy.workers_remove_capacity
      estimated_instance_warmup:   "0" => "300"

-/+ module.aws_asg_org.aws_launch_configuration.workers (new resource required)
      id:                          "production-2-workers-org-00754038303965d3f00d5b70fb" => <computed> (forces new resource)
      associate_public_ip_address: "false" => "false"
      ebs_block_device.#:          "0" => <computed>
      ebs_optimized:               "false" => <computed>
      enable_monitoring:           "true" => "true"
      image_id:                    "ami-3e405045" => "ami-3e405045"
      instance_type:               "c3.8xlarge" => "c3.8xlarge"
      key_name:                    "" => <computed>
      name:                        "production-2-workers-org-00754038303965d3f00d5b70fb" => <computed>
      name_prefix:                 "production-2-workers-org-" => "production-2-workers-org-"
      root_block_device.#:         "0" => <computed>
      security_groups.#:           "2" => "2"
      security_groups.1976880071:  "sg-902860ea" => "sg-902860ea"
      security_groups.2464611514:  "sg-9c2860e6" => "sg-9c2860e6"
      user_data:                   "b928ae11635e21dfd5a36fe0247f5478161c1afc" => "c308b27171991c3fc8ff8565c65ac3dd1f4548ad" (forces new resource)


Plan: 4 to add, 5 to change, 4 to destroy.

------------------------------------------------------------------------

```

## What feedback would you like, if any?
