### PR TITLE
Set instance filters for gcloud-cleanup

### DIFF
--- a/modules/gce_project/main.tf
+++ b/modules/gce_project/main.tf
@@ -3,6 +3,10 @@ variable "bastion_image" {}
 variable "env" {}
 variable "gcloud_cleanup_account_json" {}
 
+variable "gcloud_cleanup_instance_filters" {
+  default = "name eq ^travis-job-.*,name eq ^testing-gce-.*"
+}
+
 variable "gcloud_cleanup_instance_max_age" {
   default = "3h"
 }
@@ -396,6 +400,7 @@ resource "heroku_app" "gcloud_cleanup" {
     BUILDPACK_URL                   = "https://github.com/travis-ci/heroku-buildpack-makey-go"
     GCLOUD_CLEANUP_ACCOUNT_JSON     = "${var.gcloud_cleanup_account_json}"
     GCLOUD_CLEANUP_ENTITIES         = "instances"
+    GCLOUD_CLEANUP_INSTANCE_FILTERS = "${var.gcloud_cleanup_instance_filters}"
     GCLOUD_CLEANUP_INSTANCE_MAX_AGE = "${var.gcloud_cleanup_instance_max_age}"
     GCLOUD_CLEANUP_JOB_BOARD_URL    = "${var.gcloud_cleanup_job_board_url}"
     GCLOUD_CLEANUP_LOOP_SLEEP       = "${var.gcloud_cleanup_loop_sleep}"


### PR DESCRIPTION
so that it works with both known VM naming conventions.

Closes #262 

## What approach did you choose and why?

Set the relevant env var that is supported by gcloud-cleanup.

## How can you test this?

I tested manually by setting the env var on `gcloud-cleanup-staging-1` and `gcloud-cleanup-production-1`.