### PR TITLE
Use an OR instance name filter for gcloud-cleanup

### DIFF
--- a/modules/gce_project/main.tf
+++ b/modules/gce_project/main.tf
@@ -4,7 +4,7 @@ variable "env" {}
 variable "gcloud_cleanup_account_json" {}
 
 variable "gcloud_cleanup_instance_filters" {
-  default = "name eq testing-gce OR travis-job"
+  default = "name eq ^(testing-gce|travis-job).*"
 }
 
 variable "gcloud_cleanup_instance_max_age" {

--- a/modules/gce_project/main.tf
+++ b/modules/gce_project/main.tf
@@ -4,7 +4,7 @@ variable "env" {}
 variable "gcloud_cleanup_account_json" {}
 
 variable "gcloud_cleanup_instance_filters" {
-  default = "name eq ^travis-job-.*,name eq ^testing-gce-.*"
+  default = "name eq testing-gce OR travis-job"
 }
 
 variable "gcloud_cleanup_instance_max_age" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The filter currently in production is not matching anything because it is _AND_ filter instead of an _OR_.

## What approach did you choose and why?

Use an _OR_ filter that works for both legacy and newer-ish naming conventions.

## How can you test this?

- [x] tested in gcloud-cleanup-staging-1 heroku app