### PR TITLE
Update tfw AMI from ami-3e405045 to ami-dddb77a7

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -19,7 +19,7 @@ variable "syslog_address_org" {}
 
 variable "worker_ami" {
   # tfw 2017-09-05 16-00-17
-  default = "ami-3e405045"
+  default = "ami-dddb77a7"
 }
 
 variable "amethyst_image" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

We need to rule out an outdated docker version as a potential cause of https://github.com/travis-pro/team-blue/issues/704.

## What approach did you choose and why?

New AMI has upgraded Docker.

## How can you test this?

New AMI already in <strike>staging</strike> production.

## What feedback would you like, if any?
