### PR TITLE
Implode worker instance when 'docker info' hangs.

### DIFF
--- a/modules/aws_asg/check-docker-health.bash
+++ b/modules/aws_asg/check-docker-health.bash
@@ -2,7 +2,7 @@
 set -o errexit
 set -o pipefail
 
-# Sometimes, the docker service will be running, but certain commands (docker ps) will hang indefinitely.
+# Sometimes, the docker service will be running, but certain commands (docker info) will hang indefinitely.
 # This script detects this behavior and implodes the instance when it occurs.
 
 main() {
@@ -28,7 +28,7 @@ main() {
   fi
 
   logger "Checking docker health..."
-  result=$(timeout "${sleep_time}"s docker ps) || true
+  result=$(timeout "${sleep_time}"s docker info) || true
 
   if [ -z "${result}" ]; then
     __handle_unresponsive_docker "${run_d}"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

https://github.com/travis-infrastructure/terraform-config/pull/251 added a cron task to check docker health via `docker ps`. When we upgraded docker via https://github.com/travis-ci/travis-cookbooks/pull/928, that test became useless, because now `docker ps` doesn't hang, while other commands still do.

## What approach did you choose and why?

Check docker health via `docker info` instead of `docker ps`.

## How can you test this?

Since there's no way to reliably reproduce the underlying issue, we can test by applying, then artificially making docker seem stuck by running `stop docker` and waiting for the cron to run.

## What feedback would you like, if any?

