### PR TITLE
Ensure librato source is instance-specific if not specified

### DIFF
--- a/assets/travis-worker/travis-worker-wrapper
+++ b/assets/travis-worker/travis-worker-wrapper
@@ -25,6 +25,12 @@ main() {
     echo "TRAVIS_WORKER_GCE_ZONE=${gce_zone}" >>"${env_file}"
   fi
 
+  if [[ ! "${TRAVIS_WORKER_LIBRATO_SOURCE}" ]]; then
+    local librato_source
+    librato_source="$(__build_librato_source "${name}")"
+    echo "TRAVIS_WORKER_LIBRATO_SOURCE=${librato_source}" >>"${env_file}"
+  fi
+
   if [ -f "${TRAVIS_WORKER_PRESTART_HOOK}" ]; then
     "${TRAVIS_WORKER_PRESTART_HOOK}"
   fi
@@ -45,6 +51,17 @@ __fetch_gce_zone() {
     "http://metadata.google.internal/computeMetadata/v1/instance/zone" \
     -H "Metadata-Flavor: Google" |
     awk -F/ '{ print $NF }'
+}
+
+__build_librato_source() {
+  local name="${1}"
+
+  if [[ "${name}" == "travis-worker" ]]; then
+    hostname
+    return
+  fi
+
+  echo "$(hostname)-${name##*-}"
 }
 
 main "$@"

--- a/assets/travis-worker/travis-worker-wrapper
+++ b/assets/travis-worker/travis-worker-wrapper
@@ -27,7 +27,7 @@ main() {
 
   if [[ ! "${TRAVIS_WORKER_LIBRATO_SOURCE}" ]]; then
     local librato_source
-    librato_source="$(__build_librato_source "${name}")"
+    librato_source="$(__build_librato_source "$(hostname)" "${name}")"
     echo "TRAVIS_WORKER_LIBRATO_SOURCE=${librato_source}" >>"${env_file}"
   fi
 
@@ -54,14 +54,15 @@ __fetch_gce_zone() {
 }
 
 __build_librato_source() {
-  local name="${1}"
+  local host_name="${1}"
+  local name="${2}"
 
   if [[ "${name}" == "travis-worker" ]]; then
-    hostname
+    echo "${host_name}"
     return
   fi
 
-  echo "$(hostname)-${name##*-}"
+  echo "${host_name}-${name/travis-worker-/}"
 }
 
 main "$@"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

VMs with multiple travis-worker instances, such as GCE with `travis-worker-{a,b,c}`, currently report the same librato source across processes, via the default value of `hostname`.  This makes the task of correlating metrics with specific worker processes more difficult.

## What approach did you choose and why?

If `TRAVIS_WORKER_LIBRATO_SOURCE` is not present, generate a value which is the `hostname` + a suffix derived from the "job name", which is `$UPSTART_JOB` in the case of GCE instances run via upstart.

## How can you test this?

- [x] production canary deployment