### PR TITLE
Enable docker debug mode

### DIFF
--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -152,7 +152,7 @@ EOF
 data "template_file" "docker_daemon_json" {
   template = <<EOF
 {
-  "graph": "/mnt/docker",
+  "data-root": "/mnt/docker",
   "hosts": [
     "tcp://127.0.0.1:4243",
     "unix:///var/run/docker.sock"

--- a/modules/aws_asg/main.tf
+++ b/modules/aws_asg/main.tf
@@ -170,7 +170,8 @@ data "template_file" "docker_daemon_json" {
     "dm.metadatadev=/dev/direct-lvm/metadata",
     "dm.fs=xfs"
   ],
-  "userns-remap": "default"
+  "userns-remap": "default",
+  "debug": true
 }
 EOF
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

We have no helpful logs on instances where docker has frozen, and by the time docker freezes, it's too late to enable debug mode.

## What approach did you choose and why?

This PR will enable debug mode for docker on all worker instances.

## How can you test this?

## What feedback would you like, if any?

**Important:** Debug mode is extremely noisy due to how often travis-worker interacts with containers. We should keep an eye on disk space and other side effects (Papertrail?), and revert this soon.