### PR TITLE
Empower check-docker-health.bash to confirm implosion

### DIFF
--- a/modules/aws_asg/check-docker-health.bash
+++ b/modules/aws_asg/check-docker-health.bash
@@ -7,16 +7,16 @@ set -o pipefail
 
 main() {
   local warmup_grace_period=600
-  local post_sleep="${POST_SHUTDOWN_SLEEP}"
+  local pre_implosion_sleep="${POST_SHUTDOWN_SLEEP}"
   local sleep_time="${DOCKER_PS_SLEEP_TIME}"
   local run_d="${RUNDIR}"
-  : "${post_sleep:=300}"
+  : "${pre_implosion_sleep:=300}"
   : "${sleep_time:=5}"
   : "${run_d:=/var/tmp/travis-run.d}"
   : "${KILL_COMMAND:=kill}"
 
   if [[ -f "${run_d}/implode.confirm" ]]; then
-    __handle_implode_confirm "${run_d}" "${post_sleep}"
+    __handle_implode_confirm "${run_d}" "${pre_implosion_sleep}"
     __die imploded 42
   fi
 
@@ -45,26 +45,25 @@ main() {
 
 __handle_implode_confirm() {
   local run_d="${1}"
-  local post_sleep="${2}"
+  local pre_implosion_sleep="${2}"
 
   local reason
   reason="$(cat "${run_d}/implode.confirm" 2>/dev/null)"
   : "${reason:=not sure why}"
   "${SHUTDOWN:-/sbin/shutdown}" -P now "imploding because ${reason}"
-  sleep "${post_sleep}"
 }
 
 __handle_unresponsive_docker() {
   local run_d="${1}"
-  msg="docker appears to be unhealthy"
+  msg="docker appears to be unhealthy, initiating implosion"
   echo "$msg" | tee "${run_d}/implode"
   logger "$msg"
 
-  logger "Sleeping ${post_sleep}"
-  sleep "${post_sleep}"
+  logger "Sleeping ${pre_implosion_sleep}"
+  sleep "${pre_implosion_sleep}"
 
   if [ ! -e "${run_d}/implode" ]; then
-    logger "${run_d}/implode not found, not imploding?"
+    logger "docker previously reported as unhealthy, but ${run_d}/implode not found; not imploding?"
     __die noop 0
   fi
 
@@ -74,7 +73,7 @@ __handle_unresponsive_docker() {
     echo "$msg" | tee "${run_d}/implode.confirm"
     logger "$msg"
   else
-    logger "Running '${KILL_COMMAND} -TERM $pid' to kill travis-worker."
+    logger "Running '${KILL_COMMAND} -TERM $pid' to kill travis-worker due to unhealthy docker."
     "${KILL_COMMAND}" -TERM "$pid"
   fi
 }

--- a/modules/aws_asg/check-docker-health.bash
+++ b/modules/aws_asg/check-docker-health.bash
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -o errexit
 set -o pipefail
 
 # Sometimes, the docker service will be running, but certain commands (docker info) will hang indefinitely.
@@ -56,7 +55,7 @@ __handle_implode_confirm() {
 __handle_unresponsive_docker() {
   local run_d="${1}"
   msg="docker appears to be unhealthy, initiating implosion"
-  echo "$msg" | tee "${run_d}/implode"
+  echo "$msg" > "${run_d}/implode"
   logger "$msg"
 
   logger "Sleeping ${pre_implosion_sleep}"
@@ -70,7 +69,7 @@ __handle_unresponsive_docker() {
   pid="$(pidof travis-worker)"
   if [ -z "$pid" ]; then
     msg="No PID found for travis-worker, and docker is unhealthy; imploding via cron"
-    echo "$msg" | tee "${run_d}/implode.confirm"
+    echo "$msg" > "${run_d}/implode.confirm"
     logger "$msg"
   else
     logger "Running '${KILL_COMMAND} -TERM $pid' to kill travis-worker due to unhealthy docker."

--- a/modules/aws_asg/check-docker-health.bash
+++ b/modules/aws_asg/check-docker-health.bash
@@ -55,7 +55,7 @@ __handle_implode_confirm() {
 __handle_unresponsive_docker() {
   local run_d="${1}"
   msg="docker appears to be unhealthy, initiating implosion"
-  echo "$msg" > "${run_d}/implode"
+  echo "$msg" >"${run_d}/implode"
   logger "$msg"
 
   logger "Sleeping ${pre_implosion_sleep}"
@@ -69,7 +69,7 @@ __handle_unresponsive_docker() {
   pid="$(pidof travis-worker)"
   if [ -z "$pid" ]; then
     msg="No PID found for travis-worker, and docker is unhealthy; imploding via cron"
-    echo "$msg" > "${run_d}/implode.confirm"
+    echo "$msg" >"${run_d}/implode.confirm"
     logger "$msg"
   else
     logger "Running '${KILL_COMMAND} -TERM $pid' to kill travis-worker due to unhealthy docker."

--- a/modules/aws_asg/check-docker-health.bats
+++ b/modules/aws_asg/check-docker-health.bats
@@ -25,7 +25,6 @@ EOF
   run run_check_docker_health
 
   assert_cmd 'shutdown -P now.+imploding because docker appears to be unhealthy'
-  assert_cmd 'sleep 0.1'
   [ "${status}" -eq 42 ]
   assert_cmd "logger time=20171030T153252  prog=check-docker-health.bash status=imploded"
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Normally, `/var/tmp/travis-run.d/implode.confirm` is created by travis-worker when it finds `/var/tmp/travis-run.d/implode` upon starting.

If docker is stuck, then travis-worker doesn't necessarily have a PID, so we can't send it a `TERM` signal, so it can't start, meaning `implode.confirm` will never be created.

## What approach did you choose and why?

Allow `check-docker-health.bash` to create `implode.confirm` if `travis-worker` doesn't have a PID.

## How can you test this?

This can't really be tested on staging since we can't reproduce [the docker issue](https://github.com/moby/moby/issues/35408) this is intended to address.

## What feedback would you like, if any?

