### PR TITLE
Bump AWS production to tfw 2017-11-06 16-12-17

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -18,8 +18,8 @@ variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 
 variable "worker_ami" {
-  # tfw 2017-09-05 16-00-17
-  default = "ami-dddb77a7"
+  # tfw 2017-11-06 16-12-17
+  default = "ami-a43c8dde"
 }
 
 variable "amethyst_image" {


### PR DESCRIPTION
which includes kernel 4.13.11

## What is the problem that this PR is trying to fix?

The time since last bumping kernel version on the tfw image in use.

## What approach did you choose and why?

Assign the tfw image with kernel bumped to 4.13.11

## How can you test this?

- [x] staging deployment
- [x] `make plan && make apply`
