### PR TITLE
Cha remove custom3

### DIFF
--- a/macstadium-shared-1/Makefile
+++ b/macstadium-shared-1/Makefile
@@ -8,7 +8,6 @@ CONFIG_FILES := \
 		config/jupiter-brain-staging-org-env \
 		config/jupiter-brain-custom-1-env \
 		config/jupiter-brain-custom-2-env \
-		config/jupiter-brain-custom-3-env \
 		config/jupiter-brain-custom-4-env \
 		config/jupiter-brain-custom-5-env \
 		config/jupiter-brain-custom-6-env \
@@ -18,7 +17,6 @@ CONFIG_FILES := \
 		config/travis-worker-production-org-2 \
 		config/travis-worker-custom-1 \
 		config/travis-worker-custom-2 \
-		config/travis-worker-custom-3 \
 		config/travis-worker-custom-4 \
 		config/travis-worker-custom-5 \
 		config/travis-worker-custom-6 \
@@ -26,7 +24,6 @@ CONFIG_FILES := \
 		config/vsphere-janitor-staging-com \
 		config/vsphere-janitor-custom-1 \
 		config/vsphere-janitor-custom-2 \
-		config/vsphere-janitor-custom-3 \
 		config/vsphere-janitor-custom-4 \
 		config/vsphere-janitor-custom-5 \
 		config/vsphere-janitor-custom-6 \
@@ -59,8 +56,6 @@ $(CONFIG_FILES):
 		| sed 's/^/export /' >config/jupiter-brain-custom-1-env
 	trvs generate-config -n -p JUPITER_BRAIN -f env jupiter-brain custom-2-$(INDEX) \
 		| sed 's/^/export /' >config/jupiter-brain-custom-2-env
-	trvs generate-config -n -p JUPITER_BRAIN -f env jupiter-brain custom-3-$(INDEX) \
-		| sed 's/^/export /' >config/jupiter-brain-custom-3-env
 	trvs generate-config -n -p JUPITER_BRAIN -f env jupiter-brain custom-4-$(INDEX) \
 		| sed 's/^/export /' >config/jupiter-brain-custom-4-env
 	trvs generate-config -n -p JUPITER_BRAIN -f env jupiter-brain custom-5-$(INDEX) \
@@ -79,8 +74,6 @@ $(CONFIG_FILES):
 		| sed 's/^/export /' >config/travis-worker-custom-1
 	trvs generate-config -n -p TRAVIS_WORKER -f env macstadium-workers custom-2-$(INDEX) \
 		| sed 's/^/export /' >config/travis-worker-custom-2
-	trvs generate-config -n -p TRAVIS_WORKER -f env macstadium-workers custom-3-$(INDEX) \
-		| sed 's/^/export /' >config/travis-worker-custom-3
 	trvs generate-config -n -p TRAVIS_WORKER -f env macstadium-workers custom-4-$(INDEX) \
 		| sed 's/^/export /' >config/travis-worker-custom-4
 	trvs generate-config -n -p TRAVIS_WORKER -f env macstadium-workers custom-5-$(INDEX) \
@@ -95,8 +88,6 @@ $(CONFIG_FILES):
 		| sed 's/^/export /' >config/vsphere-janitor-custom-1
 	trvs generate-config -n -p VSPHERE_JANITOR -f env vsphere-janitor custom-2-$(INDEX) \
 		| sed 's/^/export /' >config/vsphere-janitor-custom-2
-	trvs generate-config -n -p VSPHERE_JANITOR -f env vsphere-janitor custom-3-$(INDEX) \
-		| sed 's/^/export /' >config/vsphere-janitor-custom-3
 	trvs generate-config -n -p VSPHERE_JANITOR -f env vsphere-janitor custom-4-$(INDEX) \
 		| sed 's/^/export /' >config/vsphere-janitor-custom-4
 	trvs generate-config -n -p VSPHERE_JANITOR -f env vsphere-janitor custom-5-$(INDEX) \

--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -87,7 +87,7 @@ variable "vsphere_ip" {}
 terraform {
   backend "s3" {
     bucket         = "travis-terraform-state"
-    key            = "terraform-config/macstadium-shared-1.tfstate"
+    key            = "terraform-config/macstadium-shared-1-terraform-v0.9.11.tfstate"
     region         = "us-east-1"
     encrypt        = "true"
     dynamodb_table = "travis-terraform-state"

--- a/macstadium-shared-1/main.tf
+++ b/macstadium-shared-1/main.tf
@@ -28,10 +28,6 @@ variable "jupiter_brain_custom-2_version" {
   default = "v0.2.0-58-gce0b45a"
 }
 
-variable "jupiter_brain_custom-3_version" {
-  default = "v0.2.0-58-gce0b45a"
-}
-
 variable "jupiter_brain_custom-4_version" {
   default = "v0.2.0-58-gce0b45a"
 }
@@ -213,18 +209,6 @@ module "jupiter_brain_custom_2" {
   port_suffix    = 6
 }
 
-module "jupiter_brain_custom_3" {
-  source         = "../modules/jupiter_brain_bluegreen"
-  host_id        = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_ip_address = "${module.macstadium_infrastructure.wjb_ip}"
-  ssh_user       = "${var.ssh_user}"
-  version        = "${var.jupiter_brain_custom-3_version}"
-  config_path    = "${path.module}/config/jupiter-brain-custom-3-env"
-  env            = "custom-3"
-  index          = "${var.index}"
-  port_suffix    = 7
-}
-
 module "jupiter_brain_custom_4" {
   source         = "../modules/jupiter_brain_bluegreen"
   host_id        = "${module.macstadium_infrastructure.wjb_uuid}"
@@ -393,17 +377,6 @@ module "worker_custom_2" {
   index       = "${var.index}"
 }
 
-module "worker_custom_3" {
-  source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
-  ssh_user    = "${var.ssh_user}"
-  version     = "${var.travis_worker_version}"
-  config_path = "${path.module}/config/travis-worker-custom-3"
-  env         = "custom-3"
-  index       = "${var.index}"
-}
-
 module "worker_custom_4" {
   source      = "../modules/macstadium_go_worker"
   host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
@@ -478,17 +451,6 @@ module "vsphere_janitor_custom_2" {
   version     = "${var.vsphere_janitor_version}"
   config_path = "${path.module}/config/vsphere-janitor-custom-2"
   env         = "custom-2"
-  index       = "${var.index}"
-}
-
-module "vsphere_janitor_custom_3" {
-  source      = "../modules/vsphere_janitor"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
-  ssh_user    = "${var.ssh_user}"
-  version     = "${var.vsphere_janitor_version}"
-  config_path = "${path.module}/config/vsphere-janitor-custom-3"
-  env         = "custom-3"
   index       = "${var.index}"
 }
 
@@ -602,12 +564,6 @@ module "haproxy" {
       frontend_port      = "8086"
       backend_port_blue  = "9086"
       backend_port_green = "10086"
-    },
-    {
-      name               = "jupiter-brain-custom-3"
-      frontend_port      = "8087"
-      backend_port_blue  = "9087"
-      backend_port_green = "10087"
     },
     {
       name               = "jupiter-brain-custom-4"

--- a/macstadium-shared-2/Makefile
+++ b/macstadium-shared-2/Makefile
@@ -8,7 +8,6 @@ CONFIG_FILES := \
 		config/jupiter-brain-staging-org-env \
 		config/jupiter-brain-custom-1-env \
 		config/jupiter-brain-custom-2-env \
-		config/jupiter-brain-custom-3-env \
 		config/jupiter-brain-custom-4-env \
 		config/jupiter-brain-custom-5-env \
 		config/travis-worker-staging-org-1 \
@@ -17,12 +16,10 @@ CONFIG_FILES := \
 		config/travis-worker-production-org-2 \
 		config/travis-worker-custom-1 \
 		config/travis-worker-custom-2 \
-		config/travis-worker-custom-3 \
 		config/travis-worker-custom-4 \
 		config/travis-worker-custom-5 \
 		config/vsphere-janitor-custom-1 \
 		config/vsphere-janitor-custom-2 \
-		config/vsphere-janitor-custom-3 \
 		config/vsphere-janitor-custom-4 \
 		config/vsphere-janitor-custom-5 \
 		config/vsphere-janitor-production-com \
@@ -56,8 +53,6 @@ $(CONFIG_FILES):
 		| sed 's/^/export /' >config/jupiter-brain-custom-1-env
 	trvs generate-config -n -p JUPITER_BRAIN -f env jupiter-brain custom-2-$(INDEX) \
 		| sed 's/^/export /' >config/jupiter-brain-custom-2-env
-	trvs generate-config -n -p JUPITER_BRAIN -f env jupiter-brain custom-3-$(INDEX) \
-		| sed 's/^/export /' >config/jupiter-brain-custom-3-env
 	trvs generate-config -n -p JUPITER_BRAIN -f env jupiter-brain custom-4-$(INDEX) \
 		| sed 's/^/export /' >config/jupiter-brain-custom-4-env
 	trvs generate-config -n -p JUPITER_BRAIN -f env jupiter-brain custom-5-$(INDEX) \
@@ -74,8 +69,6 @@ $(CONFIG_FILES):
 		| sed 's/^/export /' >config/travis-worker-custom-1
 	trvs generate-config -n -p TRAVIS_WORKER -f env macstadium-workers custom-2-$(INDEX) \
 		| sed 's/^/export /' >config/travis-worker-custom-2
-	trvs generate-config -n -p TRAVIS_WORKER -f env macstadium-workers custom-3-$(INDEX) \
-		| sed 's/^/export /' >config/travis-worker-custom-3
 	trvs generate-config -n -p TRAVIS_WORKER -f env macstadium-workers custom-4-$(INDEX) \
 		| sed 's/^/export /' >config/travis-worker-custom-4
 	trvs generate-config -n -p TRAVIS_WORKER -f env macstadium-workers custom-5-$(INDEX) \
@@ -84,8 +77,6 @@ $(CONFIG_FILES):
 		| sed 's/^/export /' >config/vsphere-janitor-custom-1
 	trvs generate-config -n -p VSPHERE_JANITOR -f env vsphere-janitor custom-2-$(INDEX) \
 		| sed 's/^/export /' >config/vsphere-janitor-custom-2
-	trvs generate-config -n -p VSPHERE_JANITOR -f env vsphere-janitor custom-3-$(INDEX) \
-		| sed 's/^/export /' >config/vsphere-janitor-custom-3
 	trvs generate-config -n -p VSPHERE_JANITOR -f env vsphere-janitor custom-4-$(INDEX) \
 		| sed 's/^/export /' >config/vsphere-janitor-custom-4
 	trvs generate-config -n -p VSPHERE_JANITOR -f env vsphere-janitor custom-5-$(INDEX) \

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -83,7 +83,7 @@ variable "vsphere_ip" {}
 terraform {
   backend "s3" {
     bucket         = "travis-terraform-state"
-    key            = "terraform-config/macstadium-shared-2.tfstate"
+    key            = "terraform-config/macstadium-shared-2-terraform-v0.9.11.tfstate"
     region         = "us-east-1"
     encrypt        = "true"
     dynamodb_table = "travis-terraform-state"

--- a/macstadium-shared-2/main.tf
+++ b/macstadium-shared-2/main.tf
@@ -32,10 +32,6 @@ variable "jupiter_brain_custom-2_version" {
   default = "v0.2.0-58-gce0b45a"
 }
 
-variable "jupiter_brain_custom-3_version" {
-  default = "v0.2.0-58-gce0b45a"
-}
-
 variable "jupiter_brain_custom-4_version" {
   default = "v0.2.0-58-gce0b45a"
 }
@@ -209,18 +205,6 @@ module "jupiter_brain_custom_2" {
   port_suffix    = 6
 }
 
-module "jupiter_brain_custom_3" {
-  source         = "../modules/jupiter_brain_bluegreen"
-  host_id        = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_ip_address = "${module.macstadium_infrastructure.wjb_ip}"
-  ssh_user       = "${var.ssh_user}"
-  version        = "${var.jupiter_brain_custom-3_version}"
-  config_path    = "${path.module}/config/jupiter-brain-custom-3-env"
-  env            = "custom-3"
-  index          = "${var.index}"
-  port_suffix    = 7
-}
-
 module "jupiter_brain_custom_4" {
   source         = "../modules/jupiter_brain_bluegreen"
   host_id        = "${module.macstadium_infrastructure.wjb_uuid}"
@@ -377,17 +361,6 @@ module "worker_custom_2" {
   index       = "${var.index}"
 }
 
-module "worker_custom_3" {
-  source      = "../modules/macstadium_go_worker"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
-  ssh_user    = "${var.ssh_user}"
-  version     = "${var.travis_worker_version}"
-  config_path = "${path.module}/config/travis-worker-custom-3"
-  env         = "custom-3"
-  index       = "${var.index}"
-}
-
 module "worker_custom_4" {
   source      = "../modules/macstadium_go_worker"
   host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
@@ -451,17 +424,6 @@ module "vsphere_janitor_custom_2" {
   version     = "${var.vsphere_janitor_version}"
   config_path = "${path.module}/config/vsphere-janitor-custom-2"
   env         = "custom-2"
-  index       = "${var.index}"
-}
-
-module "vsphere_janitor_custom_3" {
-  source      = "../modules/vsphere_janitor"
-  host_id     = "${module.macstadium_infrastructure.wjb_uuid}"
-  ssh_host    = "${module.macstadium_infrastructure.wjb_ip}"
-  ssh_user    = "${var.ssh_user}"
-  version     = "${var.vsphere_janitor_version}"
-  config_path = "${path.module}/config/vsphere-janitor-custom-3"
-  env         = "custom-3"
   index       = "${var.index}"
 }
 
@@ -564,12 +526,6 @@ module "haproxy" {
       frontend_port      = "8086"
       backend_port_blue  = "9086"
       backend_port_green = "10086"
-    },
-    {
-      name               = "jupiter-brain-custom-3"
-      frontend_port      = "8087"
-      backend_port_blue  = "9087"
-      backend_port_green = "10087"
     },
     {
       name               = "jupiter-brain-custom-4"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Schibsted is no longer using their dedicated macpros, aliased to custom-3

See https://travisci.slack.com/archives/C45D4L2QP/p1509720277000021
and https://travisci.slack.com/archives/C45D4L2QP/p1509714699000430
for reference.

Also see: https://github.com/travis-pro/travis-keychain/pull/378

## What approach did you choose and why?
,
Since we have no replacement for custom-3, delete it.  Keep custom-{4,5,6} same. 

## How can you test this?

`make plan` locally and see if it blends. (provided we can get a working version of Terraform :confounded: )

## What feedback would you like, if any?
Any feedback is welcome. :+1: 