### PR TITLE
Replace 4.13.11 AMI with 4.9.6 AMI

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -18,8 +18,8 @@ variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 
 variable "worker_ami" {
-  # tfw 2017-11-06 16-12-17
-  default = "ami-a43c8dde"
+  # tfw 2017-11-07 01-42-17
+  default = "ami-0e823274"
 }
 
 variable "amethyst_image" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

https://github.com/moby/moby/issues/35408

Kernel 4.13.11 might be a bit too new in comparison with Ubuntu 14.04, in particular the devicemapper version.

## What approach did you choose and why?

Kernel 4.9.6 might be a safer bet. 
