### PR TITLE
Increase TRAVIS_WORKER_DOCKER_INSPECT_INTERVAL from 500ms to 1000ms

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -93,6 +93,7 @@ ${file("${path.module}/worker.env")}
 export TRAVIS_WORKER_AMQP_URI=${module.rabbitmq_worker_config_com.uri}
 export TRAVIS_WORKER_HARD_TIMEOUT=2h
 export TRAVIS_WORKER_TRAVIS_SITE=com
+export TRAVIS_WORKER_DOCKER_INSPECT_INTERVAL=1000ms
 EOF
 }
 
@@ -108,6 +109,7 @@ ${file("${path.module}/worker.env")}
 export TRAVIS_WORKER_AMQP_URI=${module.rabbitmq_worker_config_org.uri}
 export TRAVIS_WORKER_HARD_TIMEOUT=50m0s
 export TRAVIS_WORKER_TRAVIS_SITE=org
+export TRAVIS_WORKER_DOCKER_INSPECT_INTERVAL=1000ms
 EOF
 }
 

--- a/aws-staging-1/main.tf
+++ b/aws-staging-1/main.tf
@@ -73,6 +73,7 @@ ${file("${path.module}/config/worker-com.env")}
 ${file("${path.module}/worker.env")}
 
 export TRAVIS_WORKER_TRAVIS_SITE=com
+export TRAVIS_WORKER_DOCKER_INSPECT_INTERVAL=1000ms
 EOF
 }
 
@@ -86,6 +87,7 @@ ${file("${path.module}/config/worker-org.env")}
 ${file("${path.module}/worker.env")}
 
 export TRAVIS_WORKER_TRAVIS_SITE=org
+export TRAVIS_WORKER_DOCKER_INSPECT_INTERVAL=1000ms
 EOF
 }
 


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Frequent exec inspects _might_ be aggravating [this docker issue](https://github.com/moby/moby/issues/35408).

## What approach did you choose and why?

Double the interval between exec inspections.

## How can you test this?

Apply in staging, check `docker.log`.

## What feedback would you like, if any?

