### PR TITLE
Start haproxy service on wjb-* hosts

### DIFF
--- a/modules/haproxy/haproxy.tf
+++ b/modules/haproxy/haproxy.tf
@@ -73,7 +73,7 @@ EOF
       "DEBIAN_FRONTEND=noninteractive sudo apt-get -y install haproxy",
       "sudo mv /tmp/haproxy.cfg /etc/haproxy/haproxy.cfg",
       "echo ENABLED=1 | sudo tee /etc/default/haproxy",
-      "sudo /etc/init.d/haproxy start",
+      "sudo service haproxy start",
     ]
   }
 }

--- a/modules/haproxy/haproxy.tf
+++ b/modules/haproxy/haproxy.tf
@@ -73,6 +73,7 @@ EOF
       "DEBIAN_FRONTEND=noninteractive sudo apt-get -y install haproxy",
       "sudo mv /tmp/haproxy.cfg /etc/haproxy/haproxy.cfg",
       "echo ENABLED=1 | sudo tee /etc/default/haproxy",
+      "sudo /etc/init.d/haproxy start"
     ]
   }
 }

--- a/modules/haproxy/haproxy.tf
+++ b/modules/haproxy/haproxy.tf
@@ -73,7 +73,7 @@ EOF
       "DEBIAN_FRONTEND=noninteractive sudo apt-get -y install haproxy",
       "sudo mv /tmp/haproxy.cfg /etc/haproxy/haproxy.cfg",
       "echo ENABLED=1 | sudo tee /etc/default/haproxy",
-      "sudo /etc/init.d/haproxy start"
+      "sudo /etc/init.d/haproxy start",
     ]
   }
 }


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Haproxy on `wjb-*` hosts doesn't automatically start after rebuilding hosts using terraform. 

## What approach did you choose and why?

Added a quick `sudo start` in the remote exec inline as a last step 

## How can you test this?
Since we don't have an isolated staging wjb host, I cannot. :disappointed:   but I want to merge it anyway for next time, so it is not a thing we forget. 

## What feedback would you like, if any?

Is this the right approach?  
