### PR TITLE
Replace ami-0e823274 with ami-c778fdbd in aws-production-2

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -18,8 +18,8 @@ variable "syslog_address_com" {}
 variable "syslog_address_org" {}
 
 variable "worker_ami" {
-  # tfw 2017-11-07 01-42-17
-  default = "ami-0e823274"
+  # tfw 2017-11-13 19-14-17
+  default = "ami-c778fdbd"
 }
 
 variable "amethyst_image" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

AMI source: https://github.com/travis-ci/packer-templates/pull/539

This AMI is based on Ubuntu 16.04, which will allow us to upgrade the devicemapper storage driver for Docker, which _might_ maybe hopefully address https://github.com/moby/moby/issues/35408!

## Rollout

- [ ] aws-staging-1
- [ ] aws-production-2