### PR TITLE
Automate record/publish of NAT public IP addresses

### DIFF
--- a/aws-shared-2/generated-public-ip-addresses.json
+++ b/aws-shared-2/generated-public-ip-addresses.json
@@ -1,0 +1,36 @@
+{
+  "ips_by_host": [
+    {
+      "host": "workers-nat-com-shared-2.aws-us-east-1.travisci.net",
+      "ips": [
+        "34.234.4.53",
+        "52.45.220.64",
+        "54.208.31.17",
+        "52.54.40.118"
+      ]
+    },
+    {
+      "host": "workers-nat-org-shared-2.aws-us-east-1.travisci.net",
+      "ips": [
+        "52.3.55.28",
+        "34.233.56.198",
+        "52.54.31.11",
+        "52.45.185.117"
+      ]
+    }
+  ],
+  "hosts": [
+    "workers-nat-com-shared-2.aws-us-east-1.travisci.net",
+    "workers-nat-org-shared-2.aws-us-east-1.travisci.net"
+  ],
+  "ips": [
+    "34.234.4.53",
+    "52.45.220.64",
+    "54.208.31.17",
+    "52.54.40.118",
+    "52.3.55.28",
+    "34.233.56.198",
+    "52.54.31.11",
+    "52.45.185.117"
+  ]
+}

--- a/aws-shared-2/main.tf
+++ b/aws-shared-2/main.tf
@@ -368,6 +368,22 @@ module "registry" {
   vpc_id                        = "${aws_vpc.main.id}"
 }
 
+resource "null_resource" "public_ip_addresses_json" {
+  triggers {
+    workers_com_nat_id = "${aws_route53_record.workers_com_nat.id}"
+    workers_org_nat_id = "${aws_route53_record.workers_org_nat.id}"
+  }
+
+  provisioner "local-exec" {
+    command = <<EOF
+exec ${path.module}/../bin/format-public-ip-addresses \
+    ${aws_route53_record.workers_com_nat.fqdn} \
+    ${aws_route53_record.workers_org_nat.fqdn} \
+    >${path.module}/generated-public-ip-addresses.json
+EOF
+  }
+}
+
 resource "null_resource" "outputs_signature" {
   triggers {
     bastion_security_group_1b_id = "${module.aws_bastion_1b.sg_id}"

--- a/bin/format-public-ip-addresses
+++ b/bin/format-public-ip-addresses
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'net/http'
+require 'openssl'
+
+def main(argv: ARGV)
+  generated = {
+    ips_by_host: [],
+    hosts: [],
+    ips: []
+  }
+
+  argv.each do |hostname|
+    ips = host_ips(hostname)
+    generated[:hosts] << hostname
+    generated[:ips] += ips
+    generated[:ips_by_host] << {
+      host: hostname,
+      ips: ips
+    }
+  end
+
+  $stdout.puts JSON.pretty_generate(generated)
+end
+
+def dig_jsondns_host
+  @dig_jsondns_host ||= ENV.fetch('DIG_JSONDNS_HOST', 'dig.jsondns.org')
+end
+
+def http_client
+  @http_client ||= begin
+    Net::HTTP.new(dig_jsondns_host, 443).tap do |c|
+      c.use_ssl = true
+      c.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    end
+  end
+end
+
+def host_ips(hostname)
+  response = http_client.request(Net::HTTP::Get.new("/IN/#{hostname}/A"))
+  JSON.parse(response.body).fetch('answer').map { |a| a['rdata'] }
+end
+
+main if $PROGRAM_NAME == __FILE__


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Published NAT IP addresses are currently manually updated, which tends to mean that they lag behind whenever changes are made, which results in sadness for anyone that depends on an accurate safelist of IP addresses for accessing resources across the public internet.

## What approach did you choose and why?

Generate and commit a JSON file similarly to the way we record language mappings, since the latter is already being used to automate docs.

## How can you test this?

It's done!

**Update**: please note that the IP addresses in question are Elastic IPs (EIP), but that the pool of EIPs that we "own" in our AWS account is a superset of those that we assign to NATs.  AFAICT, the way terraform works in the current setup results in these EIPs potentially around any time there are changes to the underlying NAT instances (which is rare).