### PR TITLE
Update amethyst and garnet production images

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -23,11 +23,11 @@ variable "worker_ami" {
 }
 
 variable "amethyst_image" {
-  default = "travisci/ci-amethyst:packer-1503974220"
+  default = "travisci/ci-amethyst:packer-1512508255-986baf0"
 }
 
 variable "garnet_image" {
-  default = "travisci/ci-garnet:packer-1503972846"
+  default = "travisci/ci-garnet:packer-1512502276-986baf0"
 }
 
 terraform {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Production amethyst and garnet images do not match those advertised in https://docs.travis-ci.com/user/build-environment-updates/2017-12-11/.

## What approach did you choose and why?

Update the image names to those that match the announced update.

## How can you test this?

In production! :bomb: