### PR TITLE
Roll back AWS prod to trusty-based tfw image

### DIFF
--- a/aws-production-2/main.tf
+++ b/aws-production-2/main.tf
@@ -19,7 +19,10 @@ variable "syslog_address_org" {}
 
 variable "worker_ami" {
   # tfw 2017-11-13 19-14-17
-  default = "ami-c778fdbd"
+  #default = "ami-c778fdbd"
+  # FIXME: use the xenial-based one above as was already applied via
+  # travis-infrastructure/terraform-config#294
+  default = "ami-0e823274"
 }
 
 variable "amethyst_image" {


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

The tfw AMI is showing as a change on `master` despite #294 having been merged and marked deployed 😕   Meanwhile, we are trying to update the docker images for an image rollout.

## What approach did you choose and why?

Roll back to the previous tfw AMI, as currently configured in production.

## How can you test this?

`make plan` && `make apply` 💥 