### PR TITLE
Update the language mapping after Trusty Q4 roll-out

### DIFF
--- a/aws-production-2/generated-language-mapping.json
+++ b/aws-production-2/generated-language-mapping.json
@@ -9,6 +9,5 @@
   "node_js": "travisci/ci-garnet:packer-1512502276-986baf0",
   "php": "travisci/ci-garnet:packer-1512502276-986baf0",
   "python": "travisci/ci-garnet:packer-1512502276-986baf0",
-  "ruby": "travisci/ci-garnet:packer-1512502276-986baf0",
-  "generic": "travisci/ci-garnet:packer-1512502276-986baf0"
+  "ruby": "travisci/ci-garnet:packer-1512502276-986baf0"
 }

--- a/aws-production-2/generated-language-mapping.json
+++ b/aws-production-2/generated-language-mapping.json
@@ -1,13 +1,14 @@
 {
-  "android": "travisci/ci-amethyst:packer-1503974220",
-  "erlang": "travisci/ci-amethyst:packer-1503974220",
-  "haskell": "travisci/ci-amethyst:packer-1503974220",
-  "perl": "travisci/ci-amethyst:packer-1503974220",
-  "default": "travisci/ci-garnet:packer-1503972846",
-  "go": "travisci/ci-garnet:packer-1503972846",
-  "jvm": "travisci/ci-garnet:packer-1503972846",
-  "node_js": "travisci/ci-garnet:packer-1503972846",
-  "php": "travisci/ci-garnet:packer-1503972846",
-  "python": "travisci/ci-garnet:packer-1503972846",
-  "ruby": "travisci/ci-garnet:packer-1503972846"
+  "android": "travisci/ci-amethyst:packer-1512508255-986baf0",
+  "erlang": "travisci/ci-amethyst:packer-1512508255-986baf0",
+  "haskell": "travisci/ci-amethyst:packer-1512508255-986baf0",
+  "perl": "travisci/ci-amethyst:packer-1512508255-986baf0",
+  "default": "travisci/ci-garnet:packer-1512502276-986baf0",
+  "go": "travisci/ci-garnet:packer-1512502276-986baf0",
+  "jvm": "travisci/ci-garnet:packer-1512502276-986baf0",
+  "node_js": "travisci/ci-garnet:packer-1512502276-986baf0",
+  "php": "travisci/ci-garnet:packer-1512502276-986baf0",
+  "python": "travisci/ci-garnet:packer-1512502276-986baf0",
+  "ruby": "travisci/ci-garnet:packer-1512502276-986baf0",
+  "generic": "travisci/ci-garnet:packer-1512502276-986baf0"
 }


### PR DESCRIPTION
Make sure the mapping includes the new stable images.
