### PR TITLE
aws-staging-1: correctly pass worker version to asg

### DIFF
--- a/aws-staging-1/main.tf
+++ b/aws-staging-1/main.tf
@@ -308,6 +308,7 @@ module "aws_asg_org" {
   worker_docker_image_php        = "${var.latest_docker_image_garnet}"
   worker_docker_image_python     = "${var.latest_docker_image_garnet}"
   worker_docker_image_ruby       = "${var.latest_docker_image_garnet}"
+  worker_docker_self_image       = "${var.latest_docker_image_worker}"
   worker_queue                   = "ec2"
 
   worker_subnets = [


### PR DESCRIPTION
The org staging ASG was not getting the latest worker docker image, it was getting the stable one. This fixes it so that all staging ASGs get the latest one.

refs https://github.com/travis-ci/reliability/issues/165, https://github.com/travis-ci/terraform-config/pull/530