### PR TITLE
Increase resources for apt/build-cache

### DIFF
--- a/build-caching-production-1/main.tf
+++ b/build-caching-production-1/main.tf
@@ -1,16 +1,3 @@
-variable "env" {
-  default = "production"
-}
-
-variable "github_users" {}
-
-variable "index" {
-  default = 1
-}
-
-variable "librato_email" {}
-variable "librato_token" {}
-
 variable "project" {
   default = "eco-emissary-99515"
 }
@@ -19,6 +6,17 @@ variable "region" {
   default = "us-central1"
 }
 
+variable "env" {
+  default = "production"
+}
+
+variable "index" {
+  default = 1
+}
+
+variable "github_users" {}
+variable "librato_email" {}
+variable "librato_token" {}
 variable "syslog_address_com" {}
 
 terraform {
@@ -31,11 +29,6 @@ terraform {
   }
 }
 
-provider "google" {
-  project = "${var.project}"
-  region  = "${var.region}"
-}
-
 provider "google-beta" {
   project = "${var.project}"
   region  = "${var.region}"
@@ -46,11 +39,13 @@ provider "aws" {}
 module "gce_squignix" {
   source = "../modules/gce_squignix"
 
-  env            = "${var.env}"
+  project = "${var.project}"
+  region  = "${var.region}"
+  env     = "${var.env}"
+  index   = "${var.index}"
+
   github_users   = "${var.github_users}"
-  index          = "${var.index}"
   librato_email  = "${var.librato_email}"
   librato_token  = "${var.librato_token}"
-  region         = "${var.region}"
   syslog_address = "${var.syslog_address_com}"
 }

--- a/build-caching-production-1/main.tf
+++ b/build-caching-production-1/main.tf
@@ -29,6 +29,11 @@ terraform {
   }
 }
 
+provider "google" {
+  project = "${var.project}"
+  region  = "${var.region}"
+}
+
 provider "google-beta" {
   project = "${var.project}"
   region  = "${var.region}"
@@ -39,10 +44,8 @@ provider "aws" {}
 module "gce_squignix" {
   source = "../modules/gce_squignix"
 
-  project = "${var.project}"
-  region  = "${var.region}"
-  env     = "${var.env}"
-  index   = "${var.index}"
+  env   = "${var.env}"
+  index = "${var.index}"
 
   github_users   = "${var.github_users}"
   librato_email  = "${var.librato_email}"

--- a/build-caching-production-2/main.tf
+++ b/build-caching-production-2/main.tf
@@ -1,16 +1,3 @@
-variable "env" {
-  default = "production"
-}
-
-variable "github_users" {}
-
-variable "index" {
-  default = 2
-}
-
-variable "librato_email" {}
-variable "librato_token" {}
-
 variable "project" {
   default = "travis-ci-prod-2"
 }
@@ -19,6 +6,17 @@ variable "region" {
   default = "us-central1"
 }
 
+variable "env" {
+  default = "production"
+}
+
+variable "index" {
+  default = 2
+}
+
+variable "github_users" {}
+variable "librato_email" {}
+variable "librato_token" {}
 variable "syslog_address_com" {}
 
 terraform {
@@ -31,11 +29,6 @@ terraform {
   }
 }
 
-provider "google" {
-  project = "${var.project}"
-  region  = "${var.region}"
-}
-
 provider "google-beta" {
   project = "${var.project}"
   region  = "${var.region}"
@@ -46,11 +39,13 @@ provider "aws" {}
 module "gce_squignix" {
   source = "../modules/gce_squignix"
 
-  env            = "${var.env}"
+  project = "${var.project}"
+  region  = "${var.region}"
+  env     = "${var.env}"
+  index   = "${var.index}"
+
   github_users   = "${var.github_users}"
-  index          = "${var.index}"
   librato_email  = "${var.librato_email}"
   librato_token  = "${var.librato_token}"
-  region         = "${var.region}"
   syslog_address = "${var.syslog_address_com}"
 }

--- a/build-caching-production-2/main.tf
+++ b/build-caching-production-2/main.tf
@@ -29,6 +29,11 @@ terraform {
   }
 }
 
+provider "google" {
+  project = "${var.project}"
+  region  = "${var.region}"
+}
+
 provider "google-beta" {
   project = "${var.project}"
   region  = "${var.region}"
@@ -39,10 +44,8 @@ provider "aws" {}
 module "gce_squignix" {
   source = "../modules/gce_squignix"
 
-  project = "${var.project}"
-  region  = "${var.region}"
-  env     = "${var.env}"
-  index   = "${var.index}"
+  env   = "${var.env}"
+  index = "${var.index}"
 
   github_users   = "${var.github_users}"
   librato_email  = "${var.librato_email}"

--- a/build-caching-production-3/main.tf
+++ b/build-caching-production-3/main.tf
@@ -1,24 +1,22 @@
-variable "env" {
-  default = "production"
-}
-
-variable "github_users" {}
-
-variable "index" {
-  default = 3
-}
-
-variable "librato_email" {}
-variable "librato_token" {}
-
 variable "project" {
   default = "travis-ci-prod-3"
 }
 
 variable "region" {
-  default = "us-central1"
+  default = "us-east1"
 }
 
+variable "env" {
+  default = "production"
+}
+
+variable "index" {
+  default = 3
+}
+
+variable "github_users" {}
+variable "librato_email" {}
+variable "librato_token" {}
 variable "syslog_address_com" {}
 
 terraform {
@@ -31,11 +29,6 @@ terraform {
   }
 }
 
-provider "google" {
-  project = "${var.project}"
-  region  = "${var.region}"
-}
-
 provider "google-beta" {
   project = "${var.project}"
   region  = "${var.region}"
@@ -46,11 +39,13 @@ provider "aws" {}
 module "gce_squignix" {
   source = "../modules/gce_squignix"
 
-  env            = "${var.env}"
+  project = "${var.project}"
+  region  = "${var.region}"
+  env     = "${var.env}"
+  index   = "${var.index}"
+
   github_users   = "${var.github_users}"
-  index          = "${var.index}"
   librato_email  = "${var.librato_email}"
   librato_token  = "${var.librato_token}"
-  region         = "${var.region}"
   syslog_address = "${var.syslog_address_com}"
 }

--- a/build-caching-production-3/main.tf
+++ b/build-caching-production-3/main.tf
@@ -29,6 +29,11 @@ terraform {
   }
 }
 
+provider "google" {
+  project = "${var.project}"
+  region  = "${var.region}"
+}
+
 provider "google-beta" {
   project = "${var.project}"
   region  = "${var.region}"
@@ -39,13 +44,18 @@ provider "aws" {}
 module "gce_squignix" {
   source = "../modules/gce_squignix"
 
-  project = "${var.project}"
-  region  = "${var.region}"
-  env     = "${var.env}"
-  index   = "${var.index}"
+  env   = "${var.env}"
+  index = "${var.index}"
 
   github_users   = "${var.github_users}"
   librato_email  = "${var.librato_email}"
   librato_token  = "${var.librato_token}"
   syslog_address = "${var.syslog_address_com}"
+
+  network = "${google_compute_network.main.self_link}"
+}
+
+resource "google_compute_network" "main" {
+  name                    = "main"
+  auto_create_subnetworks = "false"
 }

--- a/build-caching-staging-1/main.tf
+++ b/build-caching-staging-1/main.tf
@@ -50,6 +50,7 @@ module "gce_squignix" {
   syslog_address = "${var.syslog_address_com}"
 
   cache_size_mb = 51200
+  machine_type  = "g1-small"
 }
 
 resource "null_resource" "build_cache_config" {

--- a/build-caching-staging-1/main.tf
+++ b/build-caching-staging-1/main.tf
@@ -1,16 +1,3 @@
-variable "env" {
-  default = "staging"
-}
-
-variable "github_users" {}
-
-variable "index" {
-  default = 1
-}
-
-variable "librato_email" {}
-variable "librato_token" {}
-
 variable "project" {
   default = "travis-staging-1"
 }
@@ -19,6 +6,17 @@ variable "region" {
   default = "us-central1"
 }
 
+variable "env" {
+  default = "staging"
+}
+
+variable "index" {
+  default = 1
+}
+
+variable "github_users" {}
+variable "librato_email" {}
+variable "librato_token" {}
 variable "syslog_address_com" {}
 
 terraform {
@@ -31,11 +29,6 @@ terraform {
   }
 }
 
-provider "google" {
-  project = "${var.project}"
-  region  = "${var.region}"
-}
-
 provider "google-beta" {
   project = "${var.project}"
   region  = "${var.region}"
@@ -46,14 +39,17 @@ provider "aws" {}
 module "gce_squignix" {
   source = "../modules/gce_squignix"
 
-  cache_size_mb  = 51200
-  env            = "${var.env}"
+  project = "${var.project}"
+  region  = "${var.region}"
+  env     = "${var.env}"
+  index   = "${var.index}"
+
   github_users   = "${var.github_users}"
-  index          = "${var.index}"
   librato_email  = "${var.librato_email}"
   librato_token  = "${var.librato_token}"
-  region         = "${var.region}"
   syslog_address = "${var.syslog_address_com}"
+
+  cache_size_mb = 51200
 }
 
 resource "null_resource" "build_cache_config" {

--- a/build-caching-staging-1/main.tf
+++ b/build-caching-staging-1/main.tf
@@ -29,6 +29,11 @@ terraform {
   }
 }
 
+provider "google" {
+  project = "${var.project}"
+  region  = "${var.region}"
+}
+
 provider "google-beta" {
   project = "${var.project}"
   region  = "${var.region}"
@@ -39,10 +44,8 @@ provider "aws" {}
 module "gce_squignix" {
   source = "../modules/gce_squignix"
 
-  project = "${var.project}"
-  region  = "${var.region}"
-  env     = "${var.env}"
-  index   = "${var.index}"
+  env   = "${var.env}"
+  index = "${var.index}"
 
   github_users   = "${var.github_users}"
   librato_email  = "${var.librato_email}"

--- a/modules/gce_squignix/main.tf
+++ b/modules/gce_squignix/main.tf
@@ -1,4 +1,12 @@
 variable "project" {}
+variable "region" {}
+variable "env" {}
+variable "index" {}
+
+variable "github_users" {}
+variable "librato_email" {}
+variable "librato_token" {}
+variable "syslog_address" {}
 
 variable "allowed_internal_ranges" {
   default = ["10.0.0.0/8"]
@@ -12,21 +20,12 @@ variable "dns_domain" {
   default = "travisci.net"
 }
 
-variable "env" {}
-
-variable "github_users" {}
-
 variable "gce_health_check_source_ranges" {
   default = [
     "130.211.0.0/22",
     "35.191.0.0/16",
   ]
 }
-
-variable "index" {}
-
-variable "librato_email" {}
-variable "librato_token" {}
 
 variable "machine_type" {
   default = "n1-standard-2" # 2vCPU, 7.5GB RAM
@@ -35,12 +34,6 @@ variable "machine_type" {
 variable "network" {
   default = "main"
 }
-
-variable "region" {
-  default = "us-central1"
-}
-
-variable "syslog_address" {}
 
 variable "target_size" {
   default = 2

--- a/modules/gce_squignix/main.tf
+++ b/modules/gce_squignix/main.tf
@@ -3,7 +3,7 @@ variable "allowed_internal_ranges" {
 }
 
 variable "cache_size_mb" {
-  default = 102400
+  default = 204800
 }
 
 variable "dns_domain" {
@@ -27,7 +27,7 @@ variable "librato_email" {}
 variable "librato_token" {}
 
 variable "machine_type" {
-  default = "g1-small"
+  default = "n1-standard-2" # 2vCPU, 7.5GB RAM
 }
 
 variable "network" {

--- a/modules/gce_squignix/nginx-conf.d-default.conf.tpl
+++ b/modules/gce_squignix/nginx-conf.d-default.conf.tpl
@@ -2,7 +2,7 @@
 # https://www.nginx.com/blog/nginx-caching-guide/
 # https://nginx.org/en/docs/http/ngx_http_proxy_module.html
 
-proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=my_cache:10m inactive=180m max_size=${max_size} use_temp_path=off;
+proxy_cache_path /var/cache/nginx levels=1:2 keys_zone=my_cache:10m inactive=360m max_size=${max_size} use_temp_path=off;
 
 proxy_cache my_cache;
 proxy_cache_background_update on;
@@ -11,7 +11,7 @@ proxy_cache_lock on;
 proxy_cache_methods GET HEAD;
 proxy_cache_revalidate on;
 proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-proxy_cache_valid 180m;
+proxy_cache_valid 360m;
 
 proxy_ignore_headers
         Cache-Control


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

1. Currently apt/build-cache only runs on production-2 and is manually made available to prod-1. The traffic from jobs on both projects are routed through the NATs to the caching server, this is inefficient and bad for latency.

1. Improve the HIT/MISS ratio for better user experience and lower network traffic (_assuming_ disk space costs less than network traffic).

1. Enable the apt-cache to run in a different region.


## What approach did you choose and why?
As discussed with Josh, we decided to create at least one apt/build-cache server per project and make sure the jobs use the cache through local network interfaces instead over a public interface.

## How can you test this?
We should be able to configure this on staging-1 and production-3 to see if terraform actually does what it says it will do.

- [x] Run on staging-1
- [x] Run on production-3

## What feedback would you like, if any?
No.

## Requirements
- [ ] Install apt/build-cache on production-1
- [X] Increase cache time out to 6h
- [X] Increase disk space for storing cache to ~150GB
- [X] Use persistent SSDs of ~200GB for better performance
- [x] Use local network interfaces to access the server (prerequisite: same IP/update DNS)
- [ ] Monitor HIT/MISS (https://papertrailapp.com/groups/116901/events?q=program%3Asquignix%20-GoogleHC%20MISS&focus=1082037887563878400)